### PR TITLE
Get rid of deprecation warnings

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 class InvitationsController < Devise::InvitationsController
   before_action :authenticate_user!
   before_action :require_admin, only: [:new, :create]
-  before_filter :update_sanitized_params, only: :update
+  before_action :update_sanitized_params, only: :update
 
   protected
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,8 +19,5 @@ module NewSanctuaryAsylum
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
-
-    # Do not swallow errors in after_commit/after_rollback callbacks.
-    config.active_record.raise_in_transactional_callbacks = true
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,8 +13,8 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = 'public, max-age=3600'
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/features/volunteer/user_account_management_spec.rb
+++ b/spec/features/volunteer/user_account_management_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'User account management', type: :feature do
 
     it 'does not allow editing other user accounts' do
       @other_user = create(:user, :volunteer)
-      expect { visit edit_user_path(@other_user) }.to raise_error
+      expect { visit edit_user_path(@other_user) }.to raise_error ActionController::RoutingError
     end
   end    
 end


### PR DESCRIPTION
This just gets rid of the deprecation warnings that show up when you run the tests. 