### PR TITLE
Firefox edit bug

### DIFF
--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -35,7 +35,7 @@
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
           <td>
             <div class='btn-group'>
-              <button type='button' class='btn btn-default'><%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_friend_path(friend), id: "edit-friend-#{friend.id}" %></button>
+              <%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_friend_path(friend), id: "edit-friend-#{friend.id}", class: 'btn btn-default' %>
               <button type='button' class='btn dropdown-toggle btn-default' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
                 <span class='caret'></span>
               </button>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -39,7 +39,7 @@
           <td><%= user.created_at.strftime('%m/%d/%y') %></td>
           <td>
             <div class='btn-group'>
-              <button type='button' class='btn btn-default'><%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_user_path(user), id: "edit-user-#{user.id}" %></button>
+                <%= link_to '<i class="fa fa-edit"></i>'.html_safe, edit_admin_user_path(user), id: "edit-user-#{user.id}", class: "btn btn-default" %>
               <button type='button' class='btn dropdown-toggle btn-default' data-toggle='dropdown' aria-haspopup='true' aria-expanded='false'>
                 <span class='caret'></span>
               </button>


### PR DESCRIPTION
* **bug:** when i click on the edit button on any index page in firefox, i am not redirected to the edit page
* **cause:** firefox does not recognize `<a/>` tags nested inside `<button/>` tags (!!!) [see?!](https://stackoverflow.com/questions/16280684/nesting-a-inside-button-doesnt-work-in-firefox#16280685)
* **fix:** style the `<a>` tags generated by `link_to` with `class: "btn btn-default`

* **note:** we implemented this fix for `friends` and `users`. there might be bugs in other places. we would like to catch those by implementing cross-browser feature tests in capybara

------------------
if merged, this resolves #5 