### PR TITLE
Don't activate chosen if it is already activated

### DIFF
--- a/app/assets/javascripts/admin_friend_form.js
+++ b/app/assets/javascripts/admin_friend_form.js
@@ -28,11 +28,15 @@ $(document).on('turbolinks:load', function () {
 });
 
 function activateChosen() {
-  $('.chzn-select').chosen({
-    allow_single_deselect: true,
-    no_results_text: 'No results matched',
-    width: '100%'
-  });
+  // Don't activate if the turbolink's cached version of the page
+  // already has chosen activated.
+  if ($('.chosen-container').length === 0) {
+    $('.chzn-select').chosen({
+      allow_single_deselect: true,
+      no_results_text: 'No results matched',
+      width: '100%'
+    });
+  }
 }
 
 


### PR DESCRIPTION
This is a problem if turbolinks has cached the page after the user
uses the back/foward buttons. Activating chosen again will add another
dropdown menu.