### PR TITLE
Update README to copy config/database.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ docker run --name new_sanctuary -p "127.0.0.1:5432:5432" -e POSTGRES_PASSWORD=pa
 To run initial migrations and seed the DB:
 
 ```
+cp config/database.yml.sample config/database.yml
 rake db:setup
 ```
 


### PR DESCRIPTION
# What's changed?
Add line to README for new developers getting started to instruct them to copy `config/database.yml.sample` to `config/database.yml`