### PR TITLE
Log Auth Activity

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -309,6 +309,20 @@ Devise.setup do |config|
   #   manager.default_strategies(scope: :user).unshift :some_external_strategy
   # end
 
+  Warden::Manager.after_authentication do |user,auth,opts|
+    Rails.logger.info "Forensics Login Successful: user=#{user.email}"
+  end
+
+  Warden::Manager.before_failure do |env, opts|
+    request = ActionDispatch::Request.new(env)
+    email = request.params[opts[:scope]]["email"] # opts[:scope] is expected to be :user
+    Rails.logger.warn "Forensics Login Failure: email=#{email}, ip=#{request.remote_ip}"
+  end
+
+  Warden::Manager.before_logout do |user,auth,opts|
+    Rails.logger.info "Forensics Logout: user=#{user.email}"
+  end
+
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine
   # is mountable, there are some extra configurations to be taken into account.


### PR DESCRIPTION
Co-authored-by: Max Jacobson <max@hardscrabble.net>

Set up Warden hooks and write to the log at `info` level when people log in/out or fail to authenticate.