### PR TITLE
add ruby-filemagic and document the system dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'non-stupid-digest-assets'
 gem 'airbrake', '~> 6.2'
 gem 'newrelic_rpm'
 gem 'brakeman'
+gem 'ruby-filemagic'
 
 group :assets do
   gem 'sprockets', '~> 3.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-filemagic (0.7.2)
     ruby_http_client (3.1.0)
     safe_yaml (1.0.4)
     sass (3.5.1)
@@ -360,6 +361,7 @@ DEPENDENCIES
   redis (~> 3.3.1)
   rspec-given (~> 3.8.0)
   rspec-rails (~> 3.5.0)
+  ruby-filemagic
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sendgrid-ruby
@@ -380,4 +382,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Software to support the core work of the New Sanctuary Coalition: helping our fr
 
 * ruby (see Gemfile for version)
 * postgres
+* filemagic system libraries (check out the [https://github.com/blackwinter/ruby-filemagic](filemagic gem docs) to see what to install for your OS)
 
 ### Ruby Dependencies
 


### PR DESCRIPTION
This will let us do actual file type detection for uploaded files. Looking at either the file extension or the MIME type is useless for actual file type detection because both are user-provided and easily spoofable. Our solution will look at "magic" header bits for a file and use that to determine what kind of file it actually is.