### PR TITLE
#91 family court volunteer limit

### DIFF
--- a/app/controllers/accompaniments_controller.rb
+++ b/app/controllers/accompaniments_controller.rb
@@ -10,6 +10,9 @@ class AccompanimentsController < ApplicationController
       if accompaniment.save
         flash[:success] = 'Your RSVP was successful.'
         render_activities
+      else
+        flash[:error] = accompaniment.errors.full_messages.to_sentence 
+        render_activities
       end
     else
       render_activities

--- a/app/models/accompaniment.rb
+++ b/app/models/accompaniment.rb
@@ -16,16 +16,10 @@ class Accompaniment < ApplicationRecord
   private
 
   def limit_for_family_court
-    if limit_reached? 
+    if !activity.try(:accompaniable?)
       errors.add(:activity, family_court_error)
       false
     end
-  end
-
-  def limit_reached?
-    return false if activity.try(:event) != 'family_court'
-
-    activity.accompaniments.count >= 3
   end
 
   def family_court_error

--- a/app/models/accompaniment.rb
+++ b/app/models/accompaniment.rb
@@ -23,7 +23,7 @@ class Accompaniment < ApplicationRecord
   end
 
   def family_court_error
-    "Only 3 accompaniments are allowed per family_court activity"
+    "can't exceed 3 volunteer accompaniments."
   end
 
 end

--- a/app/models/accompaniment.rb
+++ b/app/models/accompaniment.rb
@@ -3,6 +3,7 @@ class Accompaniment < ApplicationRecord
   belongs_to :activity
 
   validates :activity_id, :user_id, presence: true
+  validate :limit_for_family_court
 
   def self.find_or_build(activity, user)
     if user.attending?(activity)
@@ -11,4 +12,24 @@ class Accompaniment < ApplicationRecord
       user.accompaniments.new(activity_id: activity.id)
     end
   end
+
+  private
+
+  def limit_for_family_court
+    if limit_reached? 
+      errors.add(:activity, family_court_error)
+      false
+    end
+  end
+
+  def limit_reached?
+    return false if activity.try(:event) != 'family_court'
+
+    activity.accompaniments.count >= 3
+  end
+
+  def family_court_error
+    "Only 3 accompaniments are allowed per family_court activity"
+  end
+
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -82,6 +82,10 @@ class Activity < ApplicationRecord
                                    .confirmed.by_dates(period_begin, period_end)
                                    .order(occur_at: 'desc')
                                }
+  def accompaniable?
+    event != 'family_court' || accompaniments.count < 3
+  end
+
   def start_time
     occur_at
   end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -86,6 +86,12 @@ class Activity < ApplicationRecord
     event != 'family_court' || accompaniments.count < 3
   end
 
+  def volunteers_needed
+    if accompaniable? 
+      "#{3 - accompaniments.count} volunteers needed."
+    end
+  end
+
   def start_time
     occur_at
   end

--- a/app/views/accompaniment_leader/activities/_activity.html.erb
+++ b/app/views/accompaniment_leader/activities/_activity.html.erb
@@ -44,6 +44,9 @@
     <% else %>
       <%= link_to 'Add Accompaniment Leader Notes', new_community_accompaniment_leader_activity_accompaniment_report_path(current_community.slug, activity) %>
     <% end %>
+  <% if activity.accompaniable? %>
+    <div><em><%= activity.volunteers_needed%> </em></div>
+  <% end %>
   </div>
 
   <div class='confirm'>

--- a/app/views/accompaniment_leader/activities/_activity.html.erb
+++ b/app/views/accompaniment_leader/activities/_activity.html.erb
@@ -49,7 +49,7 @@
   <div class='confirm'>
     <% if current_user.attending?(activity) %>
       <button type='button' class='btn btn-success' data-toggle='modal' data-target="#activity_<%= activity.id %>_accompaniment_modal">Edit RSVP</button>
-    <% else %>
+    <% elsif activity.accompaniable? %>
       <button type='button' class='btn btn-primary' data-toggle='modal' data-target="#activity_<%= activity.id %>_accompaniment_modal">Attend</button>
     <% end %>
   </div>

--- a/app/views/activities/_activity.html.erb
+++ b/app/views/activities/_activity.html.erb
@@ -9,7 +9,11 @@
       <%= render 'shared/scoped_activity_users_details', activity: activity, scope: 'accompaniment_leader' %>
     <% end %>
     <strong>Volunteers:  </strong><%= activity.users.volunteer.map(&:first_name).to_sentence %>
+  <% if activity.accompaniable? %>
+    <div><em><%= activity.volunteers_needed%> </em></div>
+  <% end %>
   </div>
+
   <div class='confirm'>
     <% if current_user.attending?(activity) %>
       <button type='button' class='btn btn-success' data-toggle='modal' data-target="#activity_<%= activity.id %>_accompaniment_modal">Edit RSVP</button>

--- a/app/views/admin/friends/activities/_activity.html.erb
+++ b/app/views/admin/friends/activities/_activity.html.erb
@@ -3,6 +3,9 @@
     <strong>
       <%= link_to "#{activity.event.humanize}", edit_community_admin_friend_activity_path(current_community.slug, friend, activity), remote: true, class: 'open_activity_modal' %>
       <%= activity.occur_at.strftime("-- %I:%M %p, %A, %B %-d, %Y") %>
+      <% if activity.accompaniable? %>
+        <em>3 volunteers needed.</em>
+      <% end %>
     </strong><br>
     <% if activity.location.present? %>
       <strong>Location:  </strong><%= activity.location.name %><br>

--- a/spec/factories/activity_factory.rb
+++ b/spec/factories/activity_factory.rb
@@ -6,4 +6,8 @@ FactoryGirl.define do
     event 'master_calendar_hearing'
     occur_at 1.day.from_now
   end
+  
+  trait :family_court do
+    event 'family_court'
+  end
 end

--- a/spec/models/accompaniment_spec.rb
+++ b/spec/models/accompaniment_spec.rb
@@ -8,4 +8,62 @@ RSpec.describe Accompaniment, type: :model do
   it { is_expected.to validate_presence_of :user_id }
   it { is_expected.to validate_presence_of :activity_id }
 
+  describe '.limit_for_family_court validation' do
+    let(:user) { create :user }
+    context 'the activity is family_court' do
+      let!(:activity) { create :activity, :family_court }
+
+      context 'there are already 3 accompaniments for the activity' do
+        let!(:accompaniments) do 
+          create_list :accompaniment, 3, user_id: user.id, activity: activity
+        end
+        
+        let(:new_accompaniment) do 
+          build :accompaniment, activity: activity.reload, user: user
+        end
+
+        it 'does NOT save the accompaniment' do
+          expect{ new_accompaniment.save }.not_to change(Accompaniment, :count) 
+        end
+
+        it 'adds an error message to the accompaniment' do
+          new_accompaniment.save
+
+          expect(new_accompaniment.errors[:activity])
+            .to eq ["Only 3 accompaniments are allowed per family_court activity"]
+        end
+      end
+
+      context 'there are no accompaniments for the activity' do
+        let!(:activity) { create :activity, :family_court }
+
+        let(:new_accompaniment) do 
+          build :accompaniment, activity: activity.reload, user: user
+        end
+
+        it 'saves the accompaniment' do
+          expect{ new_accompaniment.save }
+            .to change(Accompaniment, :count).by 1        
+        end
+      end
+    end
+
+    context 'the activity is not family_court' do
+      let!(:activity) { create :activity }
+
+      context 'there are already 3 accompaniments for the activity' do
+        let!(:accompaniments) do 
+          create_list :accompaniment, 3, user_id: user.id, activity: activity
+        end
+
+         let(:new_accompaniment) do 
+          build :accompaniment, activity: activity.reload, user: user
+        end
+
+        it 'saves the accompaniment' do
+          expect{ new_accompaniment.save }.to change(Accompaniment, :count) 
+        end 
+      end
+    end
+  end
 end


### PR DESCRIPTION
This does the following and satisfies https://github.com/CZagrobelny/new_sanctuary_asylum/issues/91

-  validate only 3 accompaniments per family_court activity
-   Add error message if user attempts to RSVP when there are already 3 accompaniments
-   Hide the RSVP button on the volunteer accompaniments page ('/activities') if the viewer is not already attending and the limit is reached
-   Volunteers already attending should see an 'Edit RSVP'
-   Volunteers ('/activities') and accompaniment leaders ('/accompaniment_leader/activities') viewing upcoming activities should see the text in italics '3 volunteers needed.' below family_court activities.

Here is what the new note looks like on the volunteer page: 

<img width="1241" alt="screen shot 2018-07-22 at 9 25 45 pm" src="https://user-images.githubusercontent.com/6585221/43052761-9923fcb4-8df6-11e8-8b31-ce3d981d6852.png">

Here is what the new note looks like on the accompaniment leader page: 

<img width="1243" alt="screen shot 2018-07-22 at 9 18 29 pm" src="https://user-images.githubusercontent.com/6585221/43052772-a9dee69a-8df6-11e8-842a-076a557bd171.png">

Let me know if you'd like me to make any changes!