### PR TITLE
Display a person icon on activity details in the Accompaniments calendar

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -188,11 +188,14 @@
 
         .confirmed {
           color: #229608;
-          margin-right: 4px;
           display: inline-block;
           overflow: visible;
           font-size: 16px;
           line-height: 10px;
+        }
+
+        .event-info-icon {
+          width: 15px;
         }
       }
       dd {

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -5,7 +5,15 @@
   <h5><%= date.day %></h5>
   <dl>
   <% activities.each do |activity| %>
-      <dt><% if activity.confirmed? %><span class="confirmed">&#10003;</span><% end %><%= activity.occur_at.strftime("%I:%M %p") %></dt>
+      <dt>
+        <% if activity.confirmed? %>
+          <span class="confirmed">&#10003;</span>
+        <% end %>
+        <% if activity.accompaniment_leader_accompaniments.present? %>
+          <i class="fa fa-user" aria-hidden="true" title="Accompaniment leader attending"></i>
+        <% end %>
+        <%= activity.occur_at.strftime("%I:%M %p") %>
+      </dt>
       <dd>
         <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>"><%= "#{activity.event.humanize} for #{activity.friend.name}" %></a>
          <div id="modal_activity_<%= activity.id %>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -7,10 +7,10 @@
   <% activities.each do |activity| %>
       <dt>
         <% if activity.confirmed? %>
-          <span class="confirmed">&#10003;</span>
+          <span class="confirmed event-info-icon">&#10003;</span>
         <% end %>
         <% if activity.accompaniment_leader_accompaniments.present? %>
-          <i class="fa fa-user" aria-hidden="true" title="Accompaniment leader attending"></i>
+          <i class="fa fa-user event-info-icon" aria-hidden="true" title="Accompaniment leader attending"></i>
         <% end %>
         <%= activity.occur_at.strftime("%I:%M %p") %>
       </dt>


### PR DESCRIPTION
Resolve #94 

<img width="771" alt="screen shot 2018-08-03 at 1 39 19 pm" src="https://user-images.githubusercontent.com/10645593/43657062-a7f0dd5e-9722-11e8-8580-f1705cf95657.png">

Test plan:
- Go to users and promote someone's role to "Accompaniment Leader". Check that person icon shows up on events that they are attending.
- Confirm an event. Check that the person icon appears next to the check mark icon.