### PR TITLE
improve user experience when resetting passwords

### DIFF
--- a/app/controllers/devise_overrides/password_expired_controller.rb
+++ b/app/controllers/devise_overrides/password_expired_controller.rb
@@ -1,0 +1,15 @@
+class DeviseOverrides::PasswordExpiredController < Devise::PasswordExpiredController
+  # A slight customization of how devise_security_extension was doing things
+  def update
+    resource.extend(DeviseOverrides::UserWithPassword)
+    if resource.update_with_password(resource_params, skip_password: true)
+      warden.session(scope)['password_expired'] = false
+      set_flash_message :notice, :updated
+      bypass_sign_in resource, scope: scope
+      redirect_to stored_location_for(scope) || :root
+    else
+      clean_up_passwords(resource)
+      respond_with(resource, action: :show)
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :secure_validatable,
          :password_expirable, :password_archivable, :timeoutable,
          invite_for: 1.week
+
   attr_reader :raw_invitation_token
 
   enum role: %i[volunteer accompaniment_leader admin]

--- a/app/views/devise/password_expired/show.html.erb
+++ b/app/views/devise/password_expired/show.html.erb
@@ -6,13 +6,6 @@
 
     <div class='form-inputs'>
       <div class='row form-group'>
-        <%= f.label :current_password, 'Current password', class: 'col-md-4 control-label required' %>
-        <div class='col-md-6'>
-          <%= f.password_field :current_password, class: 'form-control' %>
-        </div>
-      </div>
-
-      <div class='row form-group'>
         <%= f.label :password, 'New password', class: 'col-md-4 control-label required' %>
         <div class='col-md-6'>
           <%= f.password_field :password, class: 'form-control' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-
-  devise_for :users, skip: :invitations
+  devise_for :users, skip: :invitations,
+    controllers: { password_expired: 'devise_overrides/password_expired' }
   devise_scope :user do
     authenticated do
       root to: 'dashboard#index', as: :root

--- a/lib/devise_overrides/user_with_password.rb
+++ b/lib/devise_overrides/user_with_password.rb
@@ -1,0 +1,20 @@
+module DeviseOverrides::UserWithPassword
+  # Taken from devise_security_extension but customized for us
+  def update_with_password(params, *options)
+    # Options is an Array containing a Hash
+    if options.first.delete(:skip_password)
+      # This is all customized for our needs
+      if params[:password].present? && params[:password_confirmation].present?
+        # We're skipping password so it shouldn't need to be deleted
+        update_attributes(params)
+      else
+        assign_attributes(params)
+        valid?
+        false
+      end
+    else
+      # Runs the code in Devise::Models::DatabaseAuthenticatable
+      super
+    end
+  end
+end

--- a/spec/features/reset_expired_account_spec.rb
+++ b/spec/features/reset_expired_account_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Resetting expired accounts', type: :feature do
+  let(:password) { '1OKlongpassphrase' }
+  let(:new_password) { '1OKreplacement' }
+  let(:user) do
+    create(:user, password: password).tap do |user|
+      user.need_change_password!
+    end
+  end
+
+  before do
+    # Necessary preliminary step
+    visit root_path
+
+    fill_in 'Email', with: user.email
+    fill_in 'Password', with: password
+    click_on 'Log in'
+
+    expect(page).to have_content('Your password is expired')
+  end
+
+  scenario 'Account should allow resetting password from link' do
+    visit root_path
+
+    expect(current_path).to eq(user_password_expired_path)
+    expect(page).to have_content('Your password is expired')
+
+    fill_in 'New password', with: new_password
+    fill_in 'Confirm new password', with: new_password
+    click_on 'Change my password'
+
+    expect(current_path).to eq(root_path)
+    expect(page).to have_content('Your new password is saved')
+  end
+end


### PR DESCRIPTION
looks like users were actually already logged in, which means they knew their passwords. took the same approach as the `devise_security_extension` already was. it's interesting/cool/weird/clever how they're extending the instance to allow Devise's original `update_with_password` to work normally everywhere else.