### PR TITLE
Add unit tests to Review and Draft

### DIFF
--- a/app/controllers/regional_admin/remote_lawyers_controller.rb
+++ b/app/controllers/regional_admin/remote_lawyers_controller.rb
@@ -27,7 +27,8 @@ class RegionalAdmin::RemoteLawyersController < AdminController
 
   def user_friend_associations_params
     persisted_friend_ids = @remote_lawyer.remote_clinic_friends.map(&:id)
-    friend_ids_params = remote_lawyer_params[:friend_ids].map{ |id| id.to_i if id.present? }.compact
+    friend_ids = remote_lawyer_params[:friend_ids]
+    friend_ids_params = friend_ids ? friend_ids.map{ |id| id.to_i if id.present? }.compact : []
     added_friend_ids = friend_ids_params - persisted_friend_ids
     removed_friend_ids = persisted_friend_ids - friend_ids_params
 

--- a/app/models/draft.rb
+++ b/app/models/draft.rb
@@ -14,7 +14,9 @@ class Draft < ApplicationRecord
                   approved
                   closed]
 
+  NO_STATUS_MESSAGE = 'No status set'
+
   def status_string
-    status ? status.humanize : 'No status set'
+    status ? status.humanize : NO_STATUS_MESSAGE
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -10,6 +10,6 @@ class Review < ApplicationRecord
   }
 
   def authored_by?(user)
-    !self.nil? && self.user == user
+    !self.author.nil? && self.user == user
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,14 +2,16 @@ class Review < ApplicationRecord
   belongs_to :draft
   belongs_to :user
 
-  validates :user, uniqueness: { scope: :draft,
-                                 message: "You already have a review for this draft" }
+  VALIDATION_MESSAGE = "You already have a review for this draft"
+
+  validates :user_id, uniqueness: { scope: :draft_id,
+                                 message: VALIDATION_MESSAGE }
 
   scope :by_user, ->(user) {
     where(user: user)
   }
 
   def authored_by?(user)
-    !self.author.nil? && self.user == user
+    !self.user.nil? && self.user == user
   end
 end

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Draft, type: :model do
+  it { should validate_presence_of(:pdf_draft) }
+  it { should validate_presence_of(:application_id) }
+  it { should belong_to(:friend) }
+  it { should belong_to(:application) }
+  it { should have_many(:user_draft_associations) }
+  it { should have_many(:users).through(:user_draft_associations) }
+  it { should have_many(:reviews) }
+
+  describe '#status_string' do
+    let(:draft) { create(:draft, status: status) }
+    subject { draft.status_string }
+
+    context 'draft has no status' do
+      let(:status) { nil }
+
+      it 'returns the default message' do
+        expect(subject).to eq(Draft::NO_STATUS_MESSAGE)
+      end
+    end
+
+    context 'draft has a status' do
+      let(:status) { 'in_progress' }
+
+      it 'returns the status in string form' do
+        expect(subject).to eq('In progress')
+      end
+    end
+  end
+end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Review, type: :model do
-  it { should validate_uniqueness_of(:user).scoped_to(:draft).with_message("You already have a review for this draft") }
+  subject { create(:review) }
+
+  it { should validate_uniqueness_of(:user_id).scoped_to(:draft_id).with_message(Review::VALIDATION_MESSAGE) }
   it { should belong_to(:user) }
   it { should belong_to(:draft) }
 
@@ -46,7 +48,7 @@ RSpec.describe Review, type: :model do
         let(:user) { not_author }
 
         it 'returns false' do
-          expect(subject).to eq true
+          expect(subject).to eq false
         end
       end
     end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Review, type: :model do
+  it { should validate_uniqueness_of(:user).scoped_to(:draft).with_message("You already have a review for this draft") }
+  it { should belong_to(:user) }
+  it { should belong_to(:draft) }
+
+  describe '#authored_by?(user)' do
+    let(:review) { create(:review, user: author) }
+    subject { review.authored_by?(user)}
+
+    context 'the review has no author' do
+      let(:author) { nil }
+
+      context 'user is nil' do
+        let(:user) { nil }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+
+      context 'user is present' do
+        let(:user) { create(:user) }
+
+        it 'returns false' do
+          expect(subject).to eq(false)
+        end
+      end
+
+    end
+
+    context 'the review has an author' do
+      let(:author) { create(:user) }
+      let(:not_author) { create(:user) }
+
+      context 'user is the author' do
+        let(:user) { author }
+
+        it 'returns true' do
+          expect(subject).to eq true
+        end
+      end
+
+      context 'user is not the author' do
+        let(:user) { not_author }
+
+        it 'returns false' do
+          expect(subject).to eq true
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_friend_association_spec.rb
+++ b/spec/models/user_friend_association_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe UserFriendAssociation, type: :model do
   describe 'creates remote relationship' do
     let(:friend) { create(:friend) }
     let(:user) { create(:user, :remote_clinic_lawyer) }
+    let(:mailer) { double(deliver_now: true) }
 
     it 'sends email to remote lawyer' do
-      expect(FriendshipAssignmentMailer).to receive(:send_assignment).once
+      expect(FriendshipAssignmentMailer).to receive(:send_assignment).once.and_return(mailer)
       UserFriendAssociation.create(user: user, friend: friend, remote: true)
     end
   end


### PR DESCRIPTION
This pull request adds RSPEC unit tests to the Review and Draft model classes. 

In addition to these unit tests, the following changes were made:
- Constantized some strings
- Changed Review uniqueness validation to use foreign keys rather than associations for testability
- Changed the Review#is_author?(user) to check for !self.user rather than !self (I don't think self should ever be falsey)
- Fixed some local flakey tests for remote_lawyers_controller and user_friend_association (let me know if these should be pulled into a separate request)