### PR TITLE
remote clinic: include phone numbers for team members

### DIFF
--- a/app/views/remote_clinic/friends/show.html.erb
+++ b/app/views/remote_clinic/friends/show.html.erb
@@ -16,7 +16,7 @@
           <%= draft.created_at.strftime("-- %A, %B %-d, %Y") %><br>
 
           <% if draft.users.present? %>
-            <strong>Team:  </strong><%= draft.users.map(&:name).to_sentence %><br>
+            <strong>Team:  </strong><%= draft.users.collect{|u| "#{u.name} (#{u.phone})"}.to_sentence %><br>
           <% end %>
 
           <% if draft.notes.present? %>


### PR DESCRIPTION
This updates the remote clinic lawyer's view of a Friend to include the phone numbers for the associated volunteers.
![phones](https://user-images.githubusercontent.com/1977279/49347008-f5c20e00-f667-11e8-8d86-21da0de0a526.png)

This should resolve https://github.com/CZagrobelny/new_sanctuary_asylum/issues/147

Tests: I didn't see any existing feature specs for remote clinic lawyers, so I wasn't sure where to add tests for this change. I'd be happy to add a feature spec for remote clinic lawyers if that would be appropriate; just wanted to check first.