### PR TITLE
Cap accompaniment

### DIFF
--- a/app/controllers/accompaniment_leader/activities_controller.rb
+++ b/app/controllers/accompaniment_leader/activities_controller.rb
@@ -2,7 +2,7 @@ class AccompanimentLeader::ActivitiesController < AccompanimentLeaderController
   def index
     week1, week2 = DatesHelper.two_weeks
     @upcoming_activities = current_region.activities
-                                         .for_time_confirmed(Activity::ACCOMPANIMENT_ELIGIBLE_EVENTS,
+                                         .for_time_confirmed(ActivityType.accompaniment_eligible,
                                                              week1.begin,
                                                              week2.end)
                                          .includes(:accompaniments, :users, :accompaniment_reports, :friend, :location)

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -6,7 +6,7 @@ class ActivitiesController < ApplicationController
   def index
     week1, week2 = DatesHelper.two_weeks
     @upcoming_activities = current_region.activities
-                                         .for_time_confirmed(Activity::ACCOMPANIMENT_ELIGIBLE_EVENTS,
+                                         .for_time_confirmed(ActivityType.accompaniment_eligible,
                                                              week1.begin,
                                                              week2.end)
                                          .includes(:accompaniments, :users, :friend, :location)

--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -3,13 +3,13 @@ class Admin::ActivitiesController < AdminController
 
   def index
     @activities = current_region.activities
-                                .where(event: Activity::NON_ACCOMPANIMENT_ELIGIBLE_EVENTS)
+                                .where(event: ActivityType.non_accompaniment_eligible)
                                 .includes(:friend, :location)
   end
 
   def accompaniments
     @activities = current_region.activities
-                                .where(event: Activity::ACCOMPANIMENT_ELIGIBLE_EVENTS)
+                                .where(event: ActivityType.accompaniment_eligible)
                                 .includes(:accompaniments, :users, :accompaniment_reports, :friend, :location)
   end
 
@@ -23,6 +23,11 @@ class Admin::ActivitiesController < AdminController
 
   def create
     @activity = current_region.activities.new(activity_params)
+    if activity.event
+      activity.activity_type = ActivityType.find_by(name: activity.event)
+    else
+      activity.event = ActivityType.find(activity.activity_type_id).name
+    end
     if activity.save
       flash[:success] = 'Activity saved.'
       redirect_to community_admin_activities_path(current_community.slug)
@@ -63,6 +68,7 @@ class Admin::ActivitiesController < AdminController
 
   def activity_params
     params.require(:activity).permit(
+      :activity_type_id,
       :event,
       :location_id,
       :friend_id,

--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -1,0 +1,15 @@
+class ActivityType < ApplicationRecord
+  validates :name, presence: true
+
+  scope :accompaniment_eligible, -> {
+    where(accompaniment_eligible: true).map { |a_t| a_t.name }
+  }
+
+  scope :non_accompaniment_eligible, -> {
+    where(accompaniment_eligible: false).map { |a_t| a_t.name }
+  }
+
+  def title_name
+    name.titlecase
+  end
+end

--- a/app/views/admin/activities/_form.html.erb
+++ b/app/views/admin/activities/_form.html.erb
@@ -14,7 +14,7 @@
     <div class='row form-group'>
       <%= f.label :event, 'Type', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= f.select :event, options_for_select(Activity::EVENTS, @activity.event), {include_blank: true}, {class: 'form-control'} %>
+        <%= collection_select(:activity, :activity_type_id, ActivityType.all, :id, :title_name, prompt: true) %>
       </div>
     </div>
 

--- a/db/migrate/20181125065921_create_activity_type.rb
+++ b/db/migrate/20181125065921_create_activity_type.rb
@@ -1,0 +1,11 @@
+class CreateActivityType < ActiveRecord::Migration[5.0]
+  def change
+    create_table :activity_types do |t|
+      t.string :name, unique: true
+      t.integer :cap
+      t.timestamps
+    end
+
+    add_reference :activities, :activity_type, foreign_key: true
+  end
+end

--- a/db/migrate/20181125204856_add_accompaniment_eligibility.rb
+++ b/db/migrate/20181125204856_add_accompaniment_eligibility.rb
@@ -1,0 +1,5 @@
+class AddAccompanimentEligibility < ActiveRecord::Migration[5.0]
+  def change
+    add_column :activity_types, :accompaniment_eligible, :boolean
+  end
+end

--- a/db/migrate/20181126034820_populate_activity_types_and_assign_type_ids.rb
+++ b/db/migrate/20181126034820_populate_activity_types_and_assign_type_ids.rb
@@ -1,0 +1,45 @@
+class PopulateActivityTypesAndAssignTypeIds < ActiveRecord::Migration[5.0]
+  def change
+    eligible_events = %w[master_calendar_hearing
+                         individual_hearing
+                         special_accompaniment
+                         check_in
+                         high_risk_ice_check_in
+                         family_court
+                         criminal_court
+                         bond_hearing
+                         fingerprinting].freeze
+
+    ineligible_events = %w[filing_asylum_application
+                           asylum_granted
+                           filing_work_permit
+                           detained
+                           guardianship_requested
+                           sijs_special_findings_form_finished
+                           sijs_application_submitted
+                           sijs_granted
+                           sijs_denied
+                           change_of_venue_submitted
+                           foia_request_submitted
+                           foia_recieved
+                           I_130_sent
+                           stay_of_deportation_filed
+                           u_visa_filed
+                           habeas_corpus_filed].freeze
+
+    for event in eligible_events do
+      new_activity_type = ActivityType.new(name: event, accompaniment_eligible: true)
+      new_activity_type.save
+    end
+    for event in ineligible_events do
+      new_activity_type = ActivityType.new(name: event, accompaniment_eligible: false)
+      new_activity_type.save
+    end
+
+    all_activities = Activity.all
+    all_activities.each do |activity|
+      activity.activity_type = ActivityType.find_by(name: activity.event)
+      activity.save
+    end
+  end
+end

--- a/db/migrate/20181206141243_family_court_cap.rb
+++ b/db/migrate/20181206141243_family_court_cap.rb
@@ -1,0 +1,9 @@
+class FamilyCourtCap < ActiveRecord::Migration[5.0]
+  def change
+    fc_act_type = ActivityType.find_by(name: 'family_court')
+    if fc_act_type
+      fc_act_type.cap = 3
+      fc_act_type.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,8 +42,18 @@ ActiveRecord::Schema.define(version: 20181212033943) do
     t.datetime "updated_at",       null: false
     t.integer  "region_id"
     t.boolean  "confirmed"
+    t.integer  "activity_type_id"
     t.text     "public_notes"
+    t.index ["activity_type_id"], name: "index_activities_on_activity_type_id", using: :btree
     t.index ["region_id"], name: "index_activities_on_region_id", using: :btree
+  end
+
+  create_table "activity_types", force: :cascade do |t|
+    t.string   "name"
+    t.integer  "cap"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.boolean  "accompaniment_eligible"
   end
 
   create_table "applications", force: :cascade do |t|
@@ -174,10 +184,10 @@ ActiveRecord::Schema.define(version: 20181212033943) do
     t.text     "foia_request_notes"
     t.integer  "community_id"
     t.integer  "region_id"
-    t.string   "state"
     t.string   "sponsor_name"
     t.string   "sponsor_phone_number"
     t.string   "sponsor_relationship"
+    t.string   "state"
     t.string   "border_crossing_status"
     t.index ["community_id"], name: "index_friends_on_community_id", using: :btree
     t.index ["region_id"], name: "index_friends_on_region_id", using: :btree
@@ -360,6 +370,7 @@ ActiveRecord::Schema.define(version: 20181212033943) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true, using: :btree
   end
 
+  add_foreign_key "activities", "activity_types"
   add_foreign_key "activities", "regions"
   add_foreign_key "communities", "regions"
   add_foreign_key "events", "communities"

--- a/spec/controllers/admin_access/activities_controller_spec.rb
+++ b/spec/controllers/admin_access/activities_controller_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Admin::ActivitiesController, type: :controller do
 
   describe "managing activities in the user's community"  do
     let!(:community) { create :community, :primary }
+    let!(:activity_type) { create :activity_type, :master_calendar_hearing }
     context 'when the community is primary' do
       describe 'GET #index' do
         it 'allows access' do

--- a/spec/factories/activity_type_factory.rb
+++ b/spec/factories/activity_type_factory.rb
@@ -1,0 +1,13 @@
+FactoryGirl.define do
+  factory :activity_type do
+    name 'family_court'
+    cap 3
+    accompaniment_eligible true
+  end
+
+  trait :master_calendar_hearing do
+    name 'master_calendar_hearing'
+    id name: "master_calendar_hearing"
+    accompaniment_eligible true
+  end
+end

--- a/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
+++ b/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Accompaniment leader viewing and reporting on accompaniments', t
   let(:region) { community.region }
   let(:team_leader) { create(:user, :accompaniment_leader, community: community) }
   let!(:activity) { create(:activity, occur_at: 1.week.from_now, region: region, confirmed: true) }
+  let!(:activity_type) { create :activity_type, :master_calendar_hearing }
   let!(:accompaniment) { create(:accompaniment, user: team_leader, activity: activity) }
   let(:accompaniment_listing) { "#{activity.event.humanize} for #{activity.friend.first_name} at #{activity.location.name}" }
   before do
@@ -20,6 +21,7 @@ RSpec.describe 'Accompaniment leader viewing and reporting on accompaniments', t
     end
 
     it 'displays full details of upcoming accompaniments' do
+      activity.activity_type = activity_type
       expect(page).to have_content(accompaniment_listing)
     end
 

--- a/spec/features/community_admin/viewing_accompaniments_calendar_spec.rb
+++ b/spec/features/community_admin/viewing_accompaniments_calendar_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Community Admin viewing the accompaniments calendar', type: :fea
   let(:region) { community.region }
   let(:team_leader) { create(:user, :accompaniment_leader, community: community) }
   let!(:activity) { create(:activity, occur_at: 1.hour.from_now, region: region, confirmed: true) }
+  let!(:activity_type) { create(:activity_type, :master_calendar_hearing) }
   let!(:accompaniment) { create(:accompaniment, user: team_leader, activity: activity) }
 
   before do
@@ -18,10 +19,12 @@ RSpec.describe 'Community Admin viewing the accompaniments calendar', type: :fea
     end
 
     it 'displays the activity event' do
+      activity.activity_type = activity_type
       expect(page).to have_content(activity.event.humanize)
     end
 
     it 'displays the activity friend name' do
+      activity.activity_type = activity_type
       expect(page).to have_content(activity.friend.name)
     end
 

--- a/spec/features/regional_admin/viewing_accompaniments_calendar_spec.rb
+++ b/spec/features/regional_admin/viewing_accompaniments_calendar_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Regional Admin', type: :feature do
   let(:region) { community.region }
   let(:team_leader) { create(:user, :accompaniment_leader, community: community) }
   let!(:activity) { create(:activity, occur_at: 1.hour.from_now, region: region, confirmed: true) }
+  let!(:activity_type) { create(:activity_type, :master_calendar_hearing) }
   let!(:accompaniment) { create(:accompaniment, user: team_leader, activity: activity) }
 
   before do
@@ -18,10 +19,12 @@ RSpec.describe 'Regional Admin', type: :feature do
     end
     
     it 'displays the activity event' do
+      activity.activity_type = activity_type
       expect(page).to have_content(activity.event.humanize)
     end
 
     it 'displays the activity friend name' do
+      activity.activity_type = activity_type
       expect(page).to have_content(activity.friend.name)
     end
 

--- a/spec/features/volunteer/accompanying_friends_spec.rb
+++ b/spec/features/volunteer/accompanying_friends_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Volunteer signing up for accompaniments', type: :feature, js: tr
   let(:region) { community.region }
   let(:volunteer) { create(:user, :volunteer, community: community) }
   let!(:activity) { create(:activity, occur_at: 1.week.from_now, region: region, confirmed: true ) }
+  let!(:activity_type) { create(:activity_type, :master_calendar_hearing) }
   let(:accompaniment_listing) { "#{activity.event.humanize} for #{activity.friend.first_name} at #{activity.location.name}" }
 
   before do
@@ -15,6 +16,7 @@ RSpec.describe 'Volunteer signing up for accompaniments', type: :feature, js: tr
 
   describe 'viewing upcoming accompaniments' do
     it 'displays full details of upcoming accompaniments' do
+      activity.activity_type = activity_type
       visit community_activities_path(community)
       change_month(activity.occur_at)
       expect(page).to have_content(accompaniment_listing)
@@ -23,6 +25,7 @@ RSpec.describe 'Volunteer signing up for accompaniments', type: :feature, js: tr
 
   describe 'signing up for an accompaniment' do
     it 'creates an RSVP' do
+      activity.activity_type = activity_type
       visit community_activities_path(community)
       change_month(activity.occur_at)
       within "#activity_#{activity.id}" do
@@ -40,6 +43,7 @@ RSpec.describe 'Volunteer signing up for accompaniments', type: :feature, js: tr
   describe 'canceling an RSVP for an accompaniment' do
     it 'deletes the RSVP' do
       create(:accompaniment, activity: activity, user: volunteer)
+      activity.activity_type = activity_type
       visit community_activities_path(community)
       change_month(activity.occur_at)
       within "#activity_#{activity.id}" do

--- a/spec/models/accompaniment_spec.rb
+++ b/spec/models/accompaniment_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Accompaniment, type: :model do
   describe '.limit_for_family_court validation' do
     let(:user) { create :user }
     context 'the activity is family_court' do
+      let!(:activity_type) { create :activity_type }
       let!(:activity) { create :activity, :family_court }
 
       context 'there are already 3 accompaniments for the activity' do
@@ -23,6 +24,7 @@ RSpec.describe Accompaniment, type: :model do
         end
 
         it 'does NOT save the accompaniment' do
+          activity.activity_type = activity_type
           expect{ new_accompaniment.save }.not_to change(Accompaniment, :count)
         end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Activity, type: :model do
   it { is_expected.to belong_to :judge }
   it { is_expected.to belong_to :location }
   it { is_expected.to belong_to :region }
+  it { is_expected.to belong_to :activity_type }
 
   it { is_expected.to validate_presence_of :friend_id }
   it { is_expected.to validate_presence_of :region_id }


### PR DESCRIPTION
Updates to the Activity model method `accompaniment_limit_met?` to check the `cap` property of the `activity_type` instead of a hard coded value for 1 type only.

I assume the ActivityType will be updated by a dev through console or directly in the database, so I don't have any validations on the model at this time, but can add them if necessary.

Migration `PopulateActivityTypesAndAssignTypeIds` will populate the `activity_types` table and the belongs_to relationships for the `activities` table.