### PR TITLE
Don't let seeds silently fail

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,75 +8,75 @@ ActiveRecord::Base.transaction do
   Rake::Task['populate_languages'].invoke
 
   # NY Region
-  ny_region = Region.create(name: 'ny')
+  ny_region = Region.create!(name: 'ny')
 
   # Florida Region
-  fl_region = Region.create(name: 'fl')
+  fl_region = Region.create!(name: 'fl')
 
   # Primary community (NYC)
-  nyc_community = Community.create(name: 'NYC',
+  nyc_community = Community.create!(name: 'NYC',
                                   slug: 'nyc',
                                   region_id: ny_region.id,
                                   primary: true)
 
   # NON-primary community (Long Island)
-  long_island_community = Community.create(name: 'Long Island',
+  long_island_community = Community.create!(name: 'Long Island',
                                           slug: 'long-island',
                                           region_id: ny_region.id,
                                           primary: false)
 
   # Primary community (Tampa)
-  tampa_community = Community.create(name: 'Tampa',
+  tampa_community = Community.create!(name: 'Tampa',
                                   slug: 'tampa',
                                   region_id: fl_region.id,
                                   primary: true)
 
   # NY Regional admin
-  ny_regional_admin = User.create(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
-  ny_regional_admin.user_regions.create(region_id: ny_region.id)
+  ny_regional_admin = User.create!(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  ny_regional_admin.user_regions.create!(region_id: ny_region.id)
 
   ## NYC Users
 
   #Accompaniment Leader User
-  User.create(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
 
   #Remote Clinic Lawyer
-  User.create(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
+  User.create!(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
 
   #Some additional NYC volunteer users
   20.times do
-    User.create(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
   end
 
   10.times do
-    User.create(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
   end
   ## Long Island Users
 
   #Accompaniment Leader User
-  User.create(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
 
 
   #Some additional Long Island volunteer users
   30.times do
-    User.create(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
   end
 
   # NYC Friends
   30.times do
-    Friend.create(first_name: Faker::Name.first_name,
+    Friend.create!(first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       a_number: rand.to_s[2..10],
       community_id: nyc_community.id,
@@ -105,7 +105,7 @@ ActiveRecord::Base.transaction do
 
   # Long Islang Friends
   30.times do
-    friend = Friend.create(first_name: Faker::Name.first_name,
+    friend = Friend.create!(first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name,
       a_number: rand.to_s[2..10],
       community_id: long_island_community.id,
@@ -133,41 +133,45 @@ ActiveRecord::Base.transaction do
   end
 
   #Lawyers
-  Lawyer.create(first_name: 'Michelle', last_name: 'Obama', region_id: ny_region.id)
-  Lawyer.create(first_name: 'Arrabella', last_name: 'Mansfield', region_id: ny_region.id)
-  Lawyer.create(first_name: 'Amal', last_name: 'Clooney', region_id: ny_region.id)
-  Lawyer.create(first_name: 'Hillary', last_name: 'Rodham', region_id: ny_region.id)
+  Lawyer.create!(first_name: 'Michelle', last_name: 'Obama', region_id: ny_region.id)
+  Lawyer.create!(first_name: 'Arrabella', last_name: 'Mansfield', region_id: ny_region.id)
+  Lawyer.create!(first_name: 'Amal', last_name: 'Clooney', region_id: ny_region.id)
+  Lawyer.create!(first_name: 'Hillary', last_name: 'Rodham', region_id: ny_region.id)
 
   #Locations
-  Location.create(name: '26 Federal Plaza', region_id: ny_region.id)
-  Location.create(name: 'Judson', region_id: ny_region.id)
-  Location.create(name: 'Varick St', region_id: ny_region.id)
+  Location.create!(name: '26 Federal Plaza', region_id: ny_region.id)
+  Location.create!(name: 'Judson', region_id: ny_region.id)
+  Location.create!(name: 'Varick St', region_id: ny_region.id)
 
   #Judges
-  Judge.create(first_name: 'Ruth', last_name: 'Bader Ginsburg', region_id: ny_region.id)
-  Judge.create(first_name: 'Sonia', last_name: 'Sotomayor', region_id: ny_region.id)
-  Judge.create(first_name: 'Elena', last_name: 'Kagan', region_id: ny_region.id)
+  Judge.create!(first_name: 'Ruth', last_name: 'Bader Ginsburg', region_id: ny_region.id)
+  Judge.create!(first_name: 'Sonia', last_name: 'Sotomayor', region_id: ny_region.id)
+  Judge.create!(first_name: 'Elena', last_name: 'Kagan', region_id: ny_region.id)
+
+  #ActivityType
+  check_in = ActivityType.create!(name: "Check In", cap: 3, accompaniment_eligible: true)
 
   #Activities
   Friend.all.each do |friend|
-    friend.activities.create(
+    friend.activities.create!(
       event: ['check_in', 'master_calendar_hearing', 'individual_hearing'].sample,
       location_id: Location.first.id,
       judge_id: Judge.first.id,
       occur_at: Faker::Time.between(1.month.ago, 1.month.from_now),
       notes: Faker::Lorem.paragraph,
       confirmed: true,
-      region_id: ny_region.id)
+      region_id: ny_region.id,
+      activity_type: check_in)
   end
 
   ##Accompaniments
   Activity.all.each do |activity|
-    activity.accompaniments.create(user_id: User.where(community_id: nyc_community.id).order("RANDOM()").first.id)
+    activity.accompaniments.create!(user_id: User.where(community_id: nyc_community.id).order("RANDOM()").first.id)
   end
 
   #Events
   30.times do |t|
-    Event.create(location: Location.order("RANDOM()").first,
+    Event.create!(location: Location.order("RANDOM()").first,
                 category: Event::CATEGORIES.sample[0],
                 date: Faker::Time.between(2.months.ago, 2.months.from_now),
                 title: "Test Event #{t}",
@@ -175,15 +179,15 @@ ActiveRecord::Base.transaction do
   end
 
   Event.all.each do |event|
-    event.user_event_attendances.create(user_id: User.where(community_id: nyc_community.id).order("RANDOM()").first.id)
-    event.friend_event_attendances.create(friend_id: Friend.where(community_id: nyc_community.id).order("RANDOM()").first.id)
+    event.user_event_attendances.create!(user_id: User.where(community_id: nyc_community.id).order("RANDOM()").first.id)
+    event.friend_event_attendances.create!(friend_id: Friend.where(community_id: nyc_community.id).order("RANDOM()").first.id)
   end
 
   #Detentions
   Friend.all[0..25].each_with_index do |friend, index|
     is_released = index % 5 == 0
     date_released = is_released ? Faker::Time.between(1.month.from_now, 1.month.ago) : nil
-    friend.detentions.create(
+    friend.detentions.create!(
       date_detained: Faker::Time.between(8.months.ago, 7.months.ago),
       date_released: date_released,
       case_status: ['immigration_court', 'bia', 'circuit_court'].sample,
@@ -194,7 +198,7 @@ ActiveRecord::Base.transaction do
 
   #Sanctuaries
   10.times do
-    Sanctuary.create(name: Faker::Company.name,
+    Sanctuary.create!(name: Faker::Company.name,
                       address: Faker::Address.street_address,
                       city: 'New York',
                       state: 'NY',


### PR DESCRIPTION
This pr does two things: 

1. It prevents the seeds file from silently failing by raising an error on unsuccessful creates. 
1. On [line 164](https://github.com/CZagrobelny/new_sanctuary_asylum/compare/master...latazzajones:update-seeds?expand=1#diff-f7a25bc30a409fc77050703fc048ca8cR164) I've added the activity_type to the activities created for friends. Activity type is required for activities to save successfully. This was the line that was causing my `rake db:seeds` to silently fail on my machine.

Hopefully this will help others with their db setup in the future. 