### PR TITLE
Issue 176/accompaniment leader can add new activity

### DIFF
--- a/app/controllers/accompaniment_leader/friends/activities_controller.rb
+++ b/app/controllers/accompaniment_leader/friends/activities_controller.rb
@@ -1,0 +1,34 @@
+class AccompanimentLeader::Friends::ActivitiesController < AccompanimentLeaderController
+  def new
+    @activity = friend.activities.new(region_id: current_region.id)
+  end
+
+  def create
+    @activity = friend.activities.build(activity_params)
+    if @activity.save
+      flash[:success] = "Activity added for #{friend.name}"
+      redirect_to community_accompaniment_leader_activities_path
+    else
+      flash.now[:error] = "There was an issue adding an activity for #{friend.name}"
+      render :new
+    end
+  end
+
+  private
+
+  def activity_params
+    params.require(:activity).permit(
+      :activity_type_id,
+      :location_id,
+      :friend_id,
+      :judge_id,
+      :occur_at,
+      :notes,
+      :public_notes
+    ).merge(region_id: current_region.id)
+  end
+
+  def friend
+    Friend.find(params[:friend_id])
+  end
+end

--- a/app/models/activity_type.rb
+++ b/app/models/activity_type.rb
@@ -1,6 +1,10 @@
 class ActivityType < ApplicationRecord
   validates :name, presence: true
 
+  scope :accompaniment_eligible, -> {
+    where(accompaniment_eligible: true)
+  }
+
   scope :by_name, -> {
     order('name asc')
   }

--- a/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
+++ b/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
@@ -83,6 +83,9 @@
                 </div>
               </div>
             <% end %>
+            <% if current_user.attending?(activity) %>
+              <%= link_to "Add Next Activity for #{activity.friend.name}", new_community_accompaniment_leader_friend_activity_path(friend_id: activity.friend.id) %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
+++ b/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
@@ -40,6 +40,8 @@
               <strong>Volunteers:  </strong>
               <%= render 'shared/scoped_activity_users_details', activity: activity, scope: 'volunteer' %>
             <% end %>
+            <div class='.text-warning'><em><%= volunteers_needed(activity) %></em></div>
+            <hr></hr>
             <% if activity.accompaniment_reports.present? %>
               <strong>Report Backs:</strong>
               <ol>
@@ -58,7 +60,6 @@
             <% else %>
               <%= link_to 'Add Report Back', new_community_accompaniment_leader_activity_accompaniment_report_path(current_community.slug, activity) %>
             <% end %>
-            <div><em><%= volunteers_needed(activity) %></em></div>
             <%= form_for [current_community, accompaniment] do |f| %>
               <%= f.hidden_field :activity_id, value: activity.id %>
               <%= f.hidden_field :user_id, value: current_user.id %>

--- a/app/views/accompaniment_leader/friends/activities/_form.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/_form.html.erb
@@ -1,0 +1,64 @@
+<% if @activity.errors.present? %>
+  <%= display_validation_errors(@activity) %>
+<% end %>
+<%= form_for([current_community, :accompaniment_leader, :friend, @activity]) do |f| %>
+  <div class='form-inputs'>
+
+    <div class='row form-group'>
+      <%= f.label :relation_id, 'Friend', class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= collection_select(:activity, :friend_id, [@activity.friend], :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :activity_type_id, 'Type', class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= collection_select(:activity, :activity_type_id, ActivityType.by_name.accompaniment_eligible, :id, :title_name, prompt: true) %>
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :location_id, 'Location', class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :judge_id, 'Judge', class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control'}) %>
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :occur_at, 'Date/Time', class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= f.date_select :occur_at, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <span>ET
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :notes, class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= f.text_area :notes, {class: 'form-control', style: 'height: 200px;'} %>
+      </div>
+    </div>
+
+    <div class='row form-group'>
+      <%= f.label :public_notes, class: 'col-md-3 col-xs-12 control-label' %>
+      <div class='col-md-6 col-xs-12'>
+        <%= f.text_area :public_notes, {class: 'form-control', style: 'height: 200px;'} %>
+      </div>
+    </div>
+
+    <div class='row'>
+      <div class='col-md-1 col-md-offset-10'>
+        <%= f.submit 'Save', class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/accompaniment_leader/friends/activities/new.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/new.html.erb
@@ -1,0 +1,3 @@
+<h1>Add Activity</h1>
+
+<%= render 'form', partials: { activity: @activity } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,9 @@ Rails.application.routes.draw do
     end
 
     namespace :accompaniment_leader do
+      resources :friends, only: [] do
+        resources :activities, controller: 'friends/activities', only: [:new, :create]
+      end
       resources :activities, only: [:index] do
         resources :accompaniment_reports, only: [:edit, :new, :create, :update]
       end


### PR DESCRIPTION
## Why is this PR needed?

This pr allows accompaniment leaders to add a new accompaniment eligible activity for a friend if they've attended the current activity. This is helpful when follow ups are scheduled that are also accompaniment eligible.

## Solution

- You'll see in the routes file that Accompaniment leaders can now access 
`accompaniment_leader/friends/activities#new` and `accompaniment_leader/friends/activities#create`. This allows accompaniment leaders to create a new activity but only for a specific friend. 
- The link to do this has been added to the bottom of the activity modal but is only visible if the accompaniment leader viewing it is attached to that activity.  

The modal now: 
<img width="468" alt="screen shot 2019-02-11 at 2 47 40 pm" src="https://user-images.githubusercontent.com/6585221/52595911-42fef080-2e0c-11e9-8987-f67978388adb.png">

### Link to associated issue: 

https://github.com/CZagrobelny/new_sanctuary_asylum/issues/176