### PR TITLE
Add jail_id to friends

### DIFF
--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -104,6 +104,7 @@ class Admin::FriendsController < AdminController
       :lawyer_represented_by,
       :lawyer_referred_to,
       :zip_code,
+      :jail_id,
       :criminal_conviction,
       :criminal_conviction_notes,
       :final_order_of_removal,

--- a/app/views/admin/friends/_detention_form_fields.html.erb
+++ b/app/views/admin/friends/_detention_form_fields.html.erb
@@ -12,6 +12,13 @@
 
 <div class='form-group'>
   <div class='col-md-12'>
+    <%= f.label :jail_id, 'Jail ID' %>
+    <%= f.text_field :jail_id %>
+  </div>
+</div>
+
+<div class='form-group'>
+  <div class='col-md-12'>
     <%= f.check_box :has_a_lawyer_for_detention %>
     <%= f.label :has_a_lawyer_for_detention, 'Has a Lawyer?' %>
   </div>

--- a/app/views/friends/_info.html.erb
+++ b/app/views/friends/_info.html.erb
@@ -63,6 +63,7 @@
 <p><strong>Notes:  </strong><%= friend.foia_request_notes %></p>
 
 <h3>Detention</h3>
+<p><strong>Jail ID:  </strong><%= friend.jail_id %></p>
 <p><strong>Has a Lawyer for Detention?  </strong><%= 'Yes' if friend.has_a_lawyer_for_detention %></p>
 <p><strong>Final Order of Removal?  </strong><%= 'Yes' if friend.final_order_of_removal %></p>
 <p><strong>Criminal Conviction?  </strong><%= 'Yes' if friend.criminal_conviction %></p>

--- a/db/migrate/20190218130938_add_jail_id_to_friends.rb
+++ b/db/migrate/20190218130938_add_jail_id_to_friends.rb
@@ -1,0 +1,5 @@
+class AddJailIdToFriends < ActiveRecord::Migration[5.0]
+  def change
+    add_column :friends, :jail_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190201124403) do
+ActiveRecord::Schema.define(version: 20190218130938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20190201124403) do
     t.string   "border_crossing_status"
     t.integer  "border_queue_number"
     t.string   "city"
+    t.string   "jail_id"
     t.index ["community_id"], name: "index_friends_on_community_id", using: :btree
     t.index ["region_id"], name: "index_friends_on_region_id", using: :btree
   end


### PR DESCRIPTION
## Why is this PR needed?
When friends are detained, we need to be able to store the id number they are issued by the jail.

## Solution
This PR adds jail_id field to friends table, the jail_id form field in edit and the jail_id information in the show view. 

### Link to associated issue: 
Closes #179