### PR TITLE
Update factories for static attributes deprecation

### DIFF
--- a/spec/factories/accompaniment_report_factory.rb
+++ b/spec/factories/accompaniment_report_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :accompaniment_report do
   	association :activity
     association :user
-  	notes 'test notes'
+  	notes { 'test notes' }
   end
 end

--- a/spec/factories/activity_factory.rb
+++ b/spec/factories/activity_factory.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     association :location
     association :region
     association :activity_type
-    occur_at 1.day.from_now
+    occur_at { 1.day.from_now }
   end
 end

--- a/spec/factories/activity_type_factory.rb
+++ b/spec/factories/activity_type_factory.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :activity_type do
-    name 'family_court'
-    accompaniment_eligible true
+    name { 'family_court' }
+    accompaniment_eligible { true }
   end
 
   trait :with_cap_3 do
-    cap 3
+    cap { 3 }
   end
 end

--- a/spec/factories/application_factory.rb
+++ b/spec/factories/application_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :application do
-    category "asylum"
+    category { "asylum" }
     association :friend
   end
 end

--- a/spec/factories/community_factory.rb
+++ b/spec/factories/community_factory.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
   end
 
   trait :primary do
-    primary true
+    primary { true }
   end
 end

--- a/spec/factories/detention_factory.rb
+++ b/spec/factories/detention_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :detention do
     association :friend
     association :location
-    case_status 'immigration_court'
+    case_status { 'immigration_court' }
   end
 end

--- a/spec/factories/event_factory.rb
+++ b/spec/factories/event_factory.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :event do
     association :location
     association :community
-    title {'Title' }
+    title { 'Title' }
     category { Event::CATEGORIES.first[0] }
     date { Time.now }
   end

--- a/spec/factories/release_factory.rb
+++ b/spec/factories/release_factory.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
       path = Rails.root.join('spec', 'support', 'images', 'nsc_logo.png')
       Rack::Test::UploadedFile.new(path, 'image/jpeg')
     end
-    category Release::TYPES.first
+    category { Release::TYPES.first }
   end
 end

--- a/spec/factories/review_factory.rb
+++ b/spec/factories/review_factory.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :review do
     association :draft
     association :user
-    notes 'A new review!'
+    notes { 'A new review!' }
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -8,44 +8,44 @@ FactoryBot.define do
     password { (Faker::Food.fruits + Faker::PhoneNumber.area_code.to_s + Faker::Food.spice).delete(' ') }
     password_confirmation { password }
     invitation_accepted_at { Time.now }
-    pledge_signed true
+    pledge_signed { true }
     association :community
   end
 
   trait :community_admin do
-    role :admin
+    role { :admin }
   end
 
   trait :volunteer do
-  	role :volunteer
+  	role { :volunteer }
   end
 
   trait :accompaniment_leader do
-    role :accompaniment_leader
+    role { :accompaniment_leader }
   end
 
   trait :regional_admin do
-    role :admin
+    role { :admin }
     after(:create) do |regional_admin|
       create(:user_region, user: regional_admin, region: regional_admin.community.region)
     end
   end
 
   trait :remote_clinic_lawyer do
-    remote_clinic_lawyer true
+    remote_clinic_lawyer {true}
   end
 
   trait :unconfirmed do
-    first_name nil
-    last_name nil
+    first_name { nil }
+    last_name { nil }
     email { Faker::Internet.unique.safe_email }
-    phone nil
-    volunteer_type nil
-    password nil
-    password_confirmation nil
-    invitation_accepted_at nil
-    invitation_token '1gFcPwUnKCzzuntMepu1'
-    invitation_created_at Time.now
-    invitation_sent_at Time.now
+    phone { nil }
+    volunteer_type { nil }
+    password { nil }
+    password_confirmation { nil }
+    invitation_accepted_at { nil }
+    invitation_token { '1gFcPwUnKCzzuntMepu1' }
+    invitation_created_at { Time.now }
+    invitation_sent_at { Time.now }
   end
 end


### PR DESCRIPTION
## Why is this PR needed?

`factory_bot` deprecated static attributes in factories

## Solution

updated to remove noisy deprecation warnings

### Link to associated issue: 

nope
