### PR TITLE
[Accompaniments] Render Friends in Detention as Red

### DIFF
--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -14,7 +14,9 @@
         <%= activity.occur_at.strftime("%I:%M %p") %>
       </dt>
       <dd>
-        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>"><%= "#{activity.activity_type.name.titlecase} for #{activity.friend.name}" %></a>
+        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>" style="color: <%= "red" if activity.friend.status == 'in_detention' %>;">
+          <%= "#{activity.activity_type.name.titlecase} for #{activity.friend.name}" %>  
+        </a>
         <span>(<%= "#{activity.volunteer_accompaniments.count}" %>)</span>
         <div id="modal_activity_<%= activity.id %>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
           <div class="modal-dialog">


### PR DESCRIPTION
<img width="1398" alt="Screenshot 2019-03-31 19 14 43" src="https://user-images.githubusercontent.com/1188988/55296566-40bb1a80-53e9-11e9-8788-c58974326581.png">
<img width="1218" alt="Screenshot 2019-03-31 18 49 44" src="https://user-images.githubusercontent.com/1188988/55296567-40bb1a80-53e9-11e9-94a8-fcb547ecc0cc.png">

## Why is this PR needed?

Accompaniments that are for friends in detention should stand out.

## Solution

Rendering link as red if status == 'in_detention'

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/201