### PR TITLE
Allow Admins to Filter Users By Role

### DIFF
--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -55,6 +55,15 @@ class Admin::ActivitiesController < AdminController
     redirect_to accompaniments_community_admin_activities_path
   end
 
+  def unconfirm
+    if activity.update(confirmed: false)
+      flash[:success] = 'Accompaniment confirmation removed.'
+    else
+      flash.now[:error] = 'There was an issue unconfirming this accompaniment.'
+    end
+    redirect_to accompaniments_community_admin_activities_path
+  end
+
   def activity
     @activity ||= current_region.activities.find(params[:id])
   end

--- a/app/controllers/admin/friends/activities_controller.rb
+++ b/app/controllers/admin/friends/activities_controller.rb
@@ -38,6 +38,15 @@ class Admin::Friends::ActivitiesController < AdminController
     redirect_to edit_community_admin_friend_path(current_community.slug, friend, tab: '#activities')
   end
 
+  def unconfirm
+    if activity.update(confirmed: false)
+      flash[:success] = 'Accompaniment confirmation removed.'
+    else
+      flash.now[:error] = 'There was an issue unconfirming this accompaniment.'
+    end
+    redirect_to edit_community_admin_friend_path(current_community.slug, friend, tab: '#activities')
+  end
+
   def activity
     @activity ||= friend.activities.find(params[:id])
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,6 +7,14 @@ class Admin::UsersController < AdminController
                                           },
                                           persistence_id: false)
 
+    @filterrific_role = initialize_filterrific(User,
+                                          params[:filterrific_role],
+                                          select_options: {
+                                            filter_role: role_options
+                                          },
+                                          persistence_id: false)
+
+
     @users = current_community.users
       .order('created_at DESC')
       .filterrific_find(@filterrific)
@@ -52,6 +60,12 @@ class Admin::UsersController < AdminController
   def volunteer_type_options
     User.volunteer_types.keys.map do |volunteer_type|
       [volunteer_type.humanize, volunteer_type]
+    end
+  end
+
+  def role_options
+    User.roles.keys.map do |role_type|
+      [role_type.humanize, role_type]
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@ class User < ApplicationRecord
       filter_last_name
       filter_email
       filter_volunteer_type
+      filter_role
     ]
   )
 
@@ -50,6 +51,10 @@ class User < ApplicationRecord
 
   scope :filter_volunteer_type, ->(volunteer_type) {
     where(volunteer_type: volunteer_type)
+  }
+
+  scope :filter_role, ->(role) {
+    where(role: role)
   }
 
   scope :filter_first_name, ->(name) {

--- a/app/views/admin/activities/_activity.html.erb
+++ b/app/views/admin/activities/_activity.html.erb
@@ -45,7 +45,7 @@
     <%= link_to "Edit Activity", edit_community_admin_activity_path(current_community.slug, activity), class: "btn btn-primary pull-left accomp-edit" %>
     <% if activity.accompaniment_eligible? %>
       <% if activity.confirmed? %>
-        <strong>Confirmed by Admin</strong>
+        <%= link_to 'Unconfirm', unconfirm_community_admin_activity_path(current_community.slug, activity), class: 'btn btn-danger pull-left' %>
       <% else %>
         <%= link_to 'Confirm', confirm_community_admin_activity_path(current_community.slug, activity), class: 'btn btn-success pull-left' %>
       <% end %>

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -14,7 +14,9 @@
         <%= activity.occur_at.strftime("%I:%M %p") %>
       </dt>
       <dd>
-        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>"><%= "#{activity.activity_type.name.titlecase} for #{activity.friend.name}" %></a>
+        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>" style="color: <%= "red" if activity.friend.status == 'in_detention' %>;">
+          <%= "#{activity.activity_type.name.titlecase} for #{activity.friend.name}" %>  
+        </a>
         <span>(<%= "#{activity.volunteer_accompaniments.count}" %>)</span>
         <div id="modal_activity_<%= activity.id %>" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
           <div class="modal-dialog">

--- a/app/views/admin/friends/activities/_activity.html.erb
+++ b/app/views/admin/friends/activities/_activity.html.erb
@@ -42,7 +42,7 @@
       <% if activity.accompaniment_eligible? %>
         <div style='float: right;'>
           <% if activity.confirmed? %>
-            <strong>Confirmed by Admin</strong>
+            <%= link_to 'Unconfirm', unconfirm_community_admin_friend_activity_path(current_community.slug, friend, activity), class: 'btn btn-danger' %>
           <% else %>
             <%= link_to 'Confirm', confirm_community_admin_friend_activity_path(current_community.slug, friend, activity), class: 'btn btn-primary' %>
           <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -20,7 +20,21 @@
     </div>
     <div class='form-group col-md-3'>
         <%= f.label :filter_volunteer_type, 'Volunteer Type' %>
-        <%= f.select(:filter_volunteer_type, @filterrific.select_options[:filter_volunteer_type], { include_blank: '- Any -' }, { class: 'form-control' }) %>
+        <%= f.select(
+          :filter_volunteer_type, 
+          @filterrific.select_options[:filter_volunteer_type], 
+          { include_blank: '- Any -' }, 
+          { class: 'form-control' },
+        ) %>
+    </div>
+    <div class='form-group col-md-3'>
+        <%= f.label :filter_role, 'Role' %>
+        <%= f.select(
+          :filter_role, 
+          @filterrific_role.select_options[:filter_role], 
+          { include_blank: '- Any -' }, 
+          { class: 'form-control' },
+        ) %>
     </div>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,12 +41,14 @@ Rails.application.routes.draw do
         end
         member do
           get :confirm
+          get :unconfirm
         end
       end
       resources :friends do
         resources :activities, controller: 'friends/activities' do
           member do
             get :confirm
+            get :unconfirm
           end
         end
         resources :detentions, controller: 'friends/detentions'


### PR DESCRIPTION
First load:
<img width="1398" alt="Screenshot 2019-04-01 01 20 14" src="https://user-images.githubusercontent.com/1188988/55305002-5269e580-541c-11e9-92fa-802a140253cb.png">

Filter with no results:
<img width="1398" alt="Screenshot 2019-04-01 01 07 12" src="https://user-images.githubusercontent.com/1188988/55305042-87763800-541c-11e9-826a-f3b16a7927d7.png">

Filter test data by different values:
<img width="1397" alt="Screenshot 2019-04-01 01 07 01" src="https://user-images.githubusercontent.com/1188988/55305051-93fa9080-541c-11e9-9e5c-25703fd23c6a.png">
<img width="1398" alt="Screenshot 2019-04-01 01 06 53" src="https://user-images.githubusercontent.com/1188988/55305052-93fa9080-541c-11e9-89db-e80d72c6b355.png">

Combine name search w/ role filter and verify results:
<img width="1396" alt="Screenshot 2019-04-01 01 06 17" src="https://user-images.githubusercontent.com/1188988/55305056-9957db00-541c-11e9-841d-2a601596acea.png">

## Why is this PR needed?

Admins need to be able to search users by role (volunteer, data entry, etc.)

## Solution

Using filteriffic, the same way filter is done for volunteer type. It's essentially a copy/paste, nothing crazy here.

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/203
