### PR TITLE
[Events] 1. Improve UI with Links To Edit Page & # Index Col

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -289,3 +289,11 @@
 .approved {
   color: #339933
 }
+
+.event_small_col {
+  width: 36px;
+}
+
+.event_centered_col {
+  padding-left: 5px;
+}

--- a/app/views/admin/events/_friend_attendance.html.erb
+++ b/app/views/admin/events/_friend_attendance.html.erb
@@ -6,13 +6,19 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
+      <th />
       <th>Name</th>
-      <th></th>
+      <th />
       </tr>
   </thead>
   <tbody>
-    <% friend_attendance.each do |attendance| %>
+    <% friend_attendance.each_with_index do |attendance, index| %>
       <tr>
+        <td class="event_small_col">
+          <div class="event_centered_col">
+            <%=h index + 1 %>
+          </div>
+        </td>
         <td>
           <%= link_to edit_community_admin_friend_path(
             current_community.slug, 
@@ -21,10 +27,12 @@
             <% "#{attendance.friend.name}" %>
           <% end %>    
         </td>
-        <td>
-          <%= link_to community_admin_event_friend_event_attendance_path(current_community.slug, event, attendance), method: :delete, remote: true do %>
-            <i class="fas fa-times"></i>
-          <% end %>
+        <td class="event_small_col">
+          <div class="event_centered_col">
+            <%= link_to community_admin_event_friend_event_attendance_path(current_community.slug, event, attendance), method: :delete, remote: true do %>
+              <i class="fas fa-times"></i>
+            <% end %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/events/_friend_attendance.html.erb
+++ b/app/views/admin/events/_friend_attendance.html.erb
@@ -13,7 +13,14 @@
   <tbody>
     <% friend_attendance.each do |attendance| %>
       <tr>
-        <td><%= attendance.friend.name %></td>
+        <td>
+          <%= link_to edit_community_admin_friend_path(
+            current_community.slug, 
+            attendance.friend,
+            ), id: "edit-user-#{attendance.friend.id}" do %>
+            <% "#{attendance.friend.name}" %>
+          <% end %>    
+        </td>
         <td>
           <%= link_to community_admin_event_friend_event_attendance_path(current_community.slug, event, attendance), method: :delete, remote: true do %>
             <i class="fas fa-times"></i>

--- a/app/views/admin/events/_friend_attendance.html.erb
+++ b/app/views/admin/events/_friend_attendance.html.erb
@@ -23,7 +23,7 @@
           <%= link_to edit_community_admin_friend_path(
             current_community.slug, 
             attendance.friend,
-            ), id: "edit-user-#{attendance.friend.id}" do %>
+            ), target: '_blank', id: "edit-user-#{attendance.friend.id}" do %>
             <% "#{attendance.friend.name}" %>
           <% end %>    
         </td>

--- a/app/views/admin/events/_volunteer_attendance.html.erb
+++ b/app/views/admin/events/_volunteer_attendance.html.erb
@@ -6,13 +6,19 @@
 <table class='table table-bordered'>
   <thead>
     <tr>
+      <th />
       <th>Name</th>
-      <th></th>
+      <th />
       </tr>
   </thead>
   <tbody>
-    <% volunteer_attendance.each do |attendance| %>
+    <% volunteer_attendance.each_with_index do |attendance, index| %>
       <tr>
+        <td class="event_small_col">
+          <div class="event_centered_col">
+            <%=h index + 1 %>
+          </div>
+        </td>
         <td>
           <%= link_to edit_community_admin_user_path(
               current_community.slug, 
@@ -22,16 +28,18 @@
             <% "#{attendance.user.name}" %>
           <% end %>
         </td>
-        <td>
-          <%= link_to community_admin_event_user_event_attendance_path(
-              current_community.slug, 
-              event, 
-              attendance,
-            ), 
-            method: :delete, 
-            remote: true do %>
-            <i class="fas fa-times"></i>
-          <% end %>
+        <td class="event_small_col">
+          <div class="event_centered_col">
+            <%= link_to community_admin_event_user_event_attendance_path(
+                current_community.slug, 
+                event, 
+                attendance,
+              ), 
+              method: :delete, 
+              remote: true do %>
+              <i class="fas fa-times"></i>
+            <% end %>
+          </div>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/events/_volunteer_attendance.html.erb
+++ b/app/views/admin/events/_volunteer_attendance.html.erb
@@ -13,9 +13,22 @@
   <tbody>
     <% volunteer_attendance.each do |attendance| %>
       <tr>
-        <td><%= attendance.user.name %></td>
         <td>
-          <%= link_to community_admin_event_user_event_attendance_path(current_community.slug, event, attendance), method: :delete, remote: true do %>
+          <%= link_to edit_community_admin_user_path(
+            current_community.slug, 
+            attendance.user,
+            ), id: "edit-user-#{attendance.user.id}" do %>
+            <% "#{attendance.user.name}" %>
+          <% end %>
+        </td>
+        <td>
+          <%= link_to community_admin_event_user_event_attendance_path(
+              current_community.slug, 
+              event, 
+              attendance,
+            ), 
+            method: :delete, 
+            remote: true do %>
             <i class="fas fa-times"></i>
           <% end %>
         </td>

--- a/app/views/admin/events/_volunteer_attendance.html.erb
+++ b/app/views/admin/events/_volunteer_attendance.html.erb
@@ -24,7 +24,7 @@
               current_community.slug, 
               attendance.user,
             ), 
-            id: "edit-user-#{attendance.user.id}" do %>
+            target: '_blank', id: "edit-user-#{attendance.user.id}" do %>
             <% "#{attendance.user.name}" %>
           <% end %>
         </td>

--- a/app/views/admin/events/_volunteer_attendance.html.erb
+++ b/app/views/admin/events/_volunteer_attendance.html.erb
@@ -15,9 +15,10 @@
       <tr>
         <td>
           <%= link_to edit_community_admin_user_path(
-            current_community.slug, 
-            attendance.user,
-            ), id: "edit-user-#{attendance.user.id}" do %>
+              current_community.slug, 
+              attendance.user,
+            ), 
+            id: "edit-user-#{attendance.user.id}" do %>
             <% "#{attendance.user.name}" %>
           <% end %>
         </td>


### PR DESCRIPTION
View events attendance:
<img width="1398" alt="Screenshot 2019-04-02 18 10 07" src="https://user-images.githubusercontent.com/1188988/55440895-1a2aea00-5577-11e9-93e1-c96b6baa0c10.png">

Clicking goes to:
<img width="1398" alt="Screenshot 2019-04-02 01 14 14" src="https://user-images.githubusercontent.com/1188988/55377813-a7712e80-54e4-11e9-8683-4788e5369bf7.png">

## Why is this PR needed?

This just allows easy access to the friend or volunteer's page.

## Solution

Add a simple link around the user's name

### Link to associated issue: 

https://github.com/CZagrobelny/new_sanctuary_asylum/issues/202
