### PR TITLE
Feature specs for uploading new Drafts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'bundler-audit'
   gem 'byebug'
   gem 'capybara', '~> 2.10', require: false
+  gem 'capybara-email'
   gem 'database_cleaner', '~> 1.5', require: false
   gem 'dotenv-rails'
   gem 'factory_bot_rails', '~> 4.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    capybara-email (3.0.1)
+      capybara (>= 2.4, < 4.0)
+      mail
     carrierwave (1.3.1)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -377,6 +380,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara (~> 2.10)
+  capybara-email
   carrierwave (~> 1.0)
   carrierwave-aws
   chosen-rails

--- a/spec/features/volunteer/upload_a_draft_spec.rb
+++ b/spec/features/volunteer/upload_a_draft_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'Remote clinic volunteer uploads a draft', type: :feature, js: tr
     scenario 'upload a draft and submit for review; should email the regional admin' do
       upload_draft_and_submit
 
-      # TODO: regional admin should get an email 'Lawyer Assignment Needed'
+      open_email(regional_admin.email)
+      expect(current_email.subject).to eq 'Lawyer assignment needed'
     end
   end
 
@@ -31,7 +32,8 @@ RSpec.describe 'Remote clinic volunteer uploads a draft', type: :feature, js: tr
     scenario 'upload a draft and submit for review; should email the remote clinic lawyer' do
       upload_draft_and_submit
 
-      # TODO: remote clinic lawyer should get an email 'Review needed'
+      open_email(remote_clinic_lawyer.email)
+      expect(current_email.subject).to eq 'Review needed'
     end
   end
 

--- a/spec/features/volunteer/upload_a_draft_spec.rb
+++ b/spec/features/volunteer/upload_a_draft_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Remote clinic volunteer uploads a draft', type: :feature, js: true do
   let(:community) { create(:community) }
   let(:volunteer) { create(:user, :volunteer, community: community) }
+  let!(:release) { create(:release, friend: friend) }
   let(:friend) { create(:friend, community: community) }
   let!(:user_friend_association) { create(:user_friend_association, friend: friend, user: volunteer)}
 
@@ -28,15 +29,19 @@ RSpec.describe 'Remote clinic volunteer uploads a draft', type: :feature, js: tr
     scenario 'upload a draft and submit for review; should email the remote clinic lawyer' do
       upload_draft_and_submit
 
-      # TODO: remote clinit lawyer should get an email 'Review needed'
+      # TODO: remote clinic lawyer should get an email 'Review needed'
     end
   end
 
   def upload_draft_and_submit
+    click_link 'Documents'
+    expect(page).to have_content 'There are no files associated with this user.'
+    click_on 'Create Document'
+    expect(page).to have_content 'New Document'
+    attach_file 'File Upload', Rails.root.join('spec', 'support', 'images', 'nsc_logo.png'), make_visible: true
+    select 'Asylum', from: 'application[category]'
     # TODO
-    # Documents tab
-    # Create Document, upload a file
-    # set type (asylum), add self to volunteers list
+    # add self to volunteers list
     # Save; should land back on Documents tab
     # should see Submit For Review button
     # click Submit For Review

--- a/spec/features/volunteer/upload_a_draft_spec.rb
+++ b/spec/features/volunteer/upload_a_draft_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Remote clinic volunteer uploads a draft', type: :feature, js: true do
+  let(:community) { create(:community) }
+  let(:volunteer) { create(:user, :volunteer, community: community) }
+  let(:friend) { create(:friend, community: community) }
+  let!(:user_friend_association) { create(:user_friend_association, friend: friend, user: volunteer)}
+
+  before do
+    login_as(volunteer)
+    visit root_path
+    click_link 'Clinic'
+    click_link friend.name
+  end
+
+  context 'there is not a remote clinic lawyer assigned to the friend yet' do
+    scenario 'upload a draft and submit for review; should email the regional admin' do
+      upload_draft_and_submit
+
+      # TODO: regional admin should get an email 'Lawyer Assignment Needed'
+    end
+  end
+
+  context 'there is a remote clinic lawyer assigned to the friend' do
+    let!(:remote_clinic_lawyer) { create(:user, :remote_clinic_lawyer) }
+    let!(:lawyer_friend_assocition) { create(:user_friend_association, user: remote_clinic_lawyer, friend: friend, remote: true) }
+
+    scenario 'upload a draft and submit for review; should email the remote clinic lawyer' do
+      upload_draft_and_submit
+
+      # TODO: remote clinit lawyer should get an email 'Review needed'
+    end
+  end
+
+  def upload_draft_and_submit
+    # TODO
+    # Documents tab
+    # Create Document, upload a file
+    # set type (asylum), add self to volunteers list
+    # Save; should land back on Documents tab
+    # should see Submit For Review button
+    # click Submit For Review
+    # should see In Review
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require 'faker'
 
 require 'capybara/rspec'
 require 'capybara/rails'
+require 'capybara/email/rspec'
 require 'capybara/poltergeist'
 require 'database_cleaner'
 require 'launchy'


### PR DESCRIPTION
## Why is this PR needed?
The Drafts feature was not well covered by feature specs.

## Solution
This adds two feature specs for a volunteer uploading a new draft and submitting it for review. We test that the appropriate email is sent depending on whether there is a remote clinic lawyer assigned to the friend.

I used the [capybara-email](https://github.com/DavyJonesLocker/capybara-email) gem to test the email sending. This gem seems pretty widely used and stable.

### Link to associated issue: 
This addresses https://github.com/CZagrobelny/new_sanctuary_asylum/issues/158