### PR TITLE
[Friends] Sort By Enter Date & Color Asylum-Eligible Green

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -298,7 +298,6 @@
   padding-left: 5px;
 }
 
-
 .friend_in_detention {
   color: #e83737;
 }

--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -297,3 +297,8 @@
 .event_centered_col {
   padding-left: 5px;
 }
+
+
+.friend_in_detention {
+  color: #e83737;
+}

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -136,6 +136,8 @@ class Friend < ApplicationRecord
       order("friends.created_at #{direction}")
     when /^border_queue_number/
       order("friends.border_queue_number #{direction}")
+    when /^date_of_entry/
+      order("friends.date_of_entry #{direction}")
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end
@@ -162,7 +164,9 @@ class Friend < ApplicationRecord
       %w[Newest created_at_desc],
       %w[Oldest created_at_asc],
       ['Border Queue Number (Low to High)', 'border_queue_number_asc'],
-      ['Border Queue Number (High to Low)', 'border_queue_number_desc']
+      ['Border Queue Number (High to Low)', 'border_queue_number_desc'],
+      ['Date of Entry (Latest to Earliest)', 'date_of_entry_asc'],
+      ['Date of Entry (Earliest to Latest)', 'date_of_entry_desc']
     ]
   end
 

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -165,8 +165,8 @@ class Friend < ApplicationRecord
       %w[Oldest created_at_asc],
       ['Border Queue Number (Low to High)', 'border_queue_number_asc'],
       ['Border Queue Number (High to Low)', 'border_queue_number_desc'],
-      ['Date of Entry (Latest to Earliest)', 'date_of_entry_asc'],
-      ['Date of Entry (Earliest to Latest)', 'date_of_entry_desc']
+      ['Date of Entry (Ascending)', 'date_of_entry_asc'],
+      ['Date of Entry (Descending)', 'date_of_entry_desc']
     ]
   end
 

--- a/app/views/admin/activities/accompaniments.html.erb
+++ b/app/views/admin/activities/accompaniments.html.erb
@@ -14,7 +14,7 @@
         <%= activity.occur_at.strftime("%I:%M %p") %>
       </dt>
       <dd>
-        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>" style="color: <%= "red" if activity.friend.status == 'in_detention' %>;">
+        <a href="#" data-toggle="modal" data-target="#modal_activity_<%= activity.id %>" class="<%= "friend_in_detention" if activity.friend.status == 'in_detention' %>">
           <%= "#{activity.activity_type.name.titlecase} for #{activity.friend.name}" %>  
         </a>
         <span>(<%= "#{activity.volunteer_accompaniments.count}" %>)</span>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -8,7 +8,6 @@
       <th>Category</th>
       <th>Title</th>
       <th>Date/Time</th>
-      <th>Volunteers ~ Friends</th>
       <th>Location</th>
       <th>Actions</th>
     </tr>
@@ -19,7 +18,6 @@
         <td><%= link_to event.category.titlecase, attendance_community_admin_event_path(current_community.slug, event) %></td>
         <td><%= event.title %></td>
         <td><%= event.date.strftime("%I:%M %p, %A, %B %-d, %Y") %></td>
-        <td><%= "#{event.user_attendances.count} ~ #{event.friend_attendances.count}" %></td>
         <td><%= event.location.name %></td>
         <td>
           <div class='btn-group'>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -8,6 +8,7 @@
       <th>Category</th>
       <th>Title</th>
       <th>Date/Time</th>
+      <th>Volunteers ~ Friends</th>
       <th>Location</th>
       <th>Actions</th>
     </tr>
@@ -18,6 +19,7 @@
         <td><%= link_to event.category.titlecase, attendance_community_admin_event_path(current_community.slug, event) %></td>
         <td><%= event.title %></td>
         <td><%= event.date.strftime("%I:%M %p, %A, %B %-d, %Y") %></td>
+        <td><%= "#{event.user_attendances.count} ~ #{event.friend_attendances.count}" %></td>
         <td><%= event.location.name %></td>
         <td>
           <div class='btn-group'>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -25,7 +25,9 @@
     </thead>
     <tbody>
       <% @friends.each do |friend| %>
-        <tr id="friend-<%=friend.id%>" style="color: <%= friend.detained? ? "red" : "black" %>;"}>
+        <tr 
+          id="friend-<%=friend.id%>" 
+          class="<%= "friend_in_detention" if friend.detained? %>">
           <td><%= friend.id %></td>
           <td><%= link_to friend.first_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
           <td><%= link_to friend.last_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -37,7 +37,9 @@
           <td><%= friend.phone %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
           <% if friend.date_of_entry? %>          
-            <td><%= friend.date_of_entry.strftime('%m/%d/%y') %></td>
+            <td style="<%= "font-weight: bold; color: #199348" if friend.date_of_entry >= 1.year.ago.to_date %>; ">
+              <%= friend.date_of_entry.strftime('%m/%d/%y') %>
+            </td>
           <% else %>
             <td />
           <% end %>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -19,7 +19,6 @@
         <% end %>
         <th>Phone Number</th>
         <th>Created</th>
-        <th>Entered</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -38,13 +37,6 @@
           <% end %>
           <td><%= friend.phone %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
-          <% if friend.date_of_entry? %>          
-            <td style="<%= "font-weight: bold; color: #199348" if friend.date_of_entry >= 1.year.ago.to_date %>; ">
-              <%= friend.date_of_entry.strftime('%m/%d/%y') %>
-            </td>
-          <% else %>
-            <td />
-          <% end %>
           <td>
             <div class='btn-group'>
               <%= link_to(edit_community_admin_friend_path(current_community.slug, friend), id: "edit-friend-#{friend.id}", class: 'btn btn-default') do %>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -19,6 +19,7 @@
         <% end %>
         <th>Phone Number</th>
         <th>Created</th>
+        <th>Entered</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -35,6 +36,11 @@
           <% end %>
           <td><%= friend.phone %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
+          <% if friend.date_of_entry? %>          
+            <td><%= friend.date_of_entry.strftime('%m/%d/%y') %></td>
+          <% else %>
+            <td />
+          <% end %>
           <td>
             <div class='btn-group'>
               <%= link_to(edit_community_admin_friend_path(current_community.slug, friend), id: "edit-friend-#{friend.id}", class: 'btn btn-default') do %>


### PR DESCRIPTION
Sort each way:
<img width="1212" alt="Screenshot 2019-04-03 23 26 32" src="https://user-images.githubusercontent.com/1188988/55527654-fabfba00-5667-11e9-9342-345bd0faea94.png">
<img width="1208" alt="Screenshot 2019-04-03 23 26 24" src="https://user-images.githubusercontent.com/1188988/55527655-fabfba00-5667-11e9-965d-f90676091bd7.png">


## Why is this PR needed?

We need friends who are eligible for asylum to be found easier, both in sorting and visually.

## Solution

I figured even with sorting, it'd be easier to have a color pop for dates that are within the year.

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/210