### PR TITLE
Searchable judges

### DIFF
--- a/app/views/accompaniment_leader/friends/activities/_form.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/_form.html.erb
@@ -21,14 +21,14 @@
     <div class='row form-group'>
       <%= f.label :location_id, 'Location', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 

--- a/app/views/admin/activities/_form.html.erb
+++ b/app/views/admin/activities/_form.html.erb
@@ -21,14 +21,14 @@
     <div class='row form-group'>
       <%= f.label :location_id, 'Location', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -29,7 +29,7 @@
     <div class='row form-group'>
       <%= f.label :location_id, 'Location', class: 'col-md-2 control-label required' %>
       <div class='col-md-6'>
-        <%= collection_select(:event, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:event, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
       </div>
     </div>
 

--- a/app/views/admin/friends/activities/_form.html.erb
+++ b/app/views/admin/friends/activities/_form.html.erb
@@ -14,14 +14,14 @@
     <div class='row form-group'>
       <%= f.label :location_id, 'Location', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
-        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
       </div>
     </div>
 
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
       </div>
     </div>
 

--- a/app/views/admin/friends/detentions/_form.html.erb
+++ b/app/views/admin/friends/detentions/_form.html.erb
@@ -21,7 +21,7 @@
     <div class='row form-group'>
       <%= f.label :location_id, 'Location', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
-        <%= collection_select(:detention, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control'}) %>
+        <%= collection_select(:detention, :location_id, locations_by_name(current_region), :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
       </div>
     </div>
 


### PR DESCRIPTION
<img width="928" alt="Screenshot 2019-04-02 20 49 15" src="https://user-images.githubusercontent.com/1188988/55529409-4aee4a80-566f-11e9-8a2f-534d23efe7f5.png">
<img width="913" alt="Screenshot 2019-04-02 20 49 01" src="https://user-images.githubusercontent.com/1188988/55529410-4aee4a80-566f-11e9-8af4-cbb88f12074b.png">

## Why is this PR needed?

Too many judges/locations make the dropdown hard to parse. 

## Solution

Now it's searchable. 

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/177