### PR TITLE
[Friends] Add "intake_notes", "must_be_seen_by", & "intake_date" Fields, Add to Form, Allow Sorting

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -297,3 +297,7 @@
 .event_centered_col {
   padding-left: 5px;
 }
+
+.form_fields_section {
+  padding-bottom: 8px;
+}

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -120,6 +120,7 @@ class Admin::FriendsController < AdminController
       :sponsor_name,
       :sponsor_phone_number,
       :sponsor_relationship,
+      :intake_notes,
       language_ids: [],
       user_ids: []
     ).merge(community_id: current_community.id, region_id: current_region.id)

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -121,6 +121,8 @@ class Admin::FriendsController < AdminController
       :sponsor_phone_number,
       :sponsor_relationship,
       :intake_notes,
+      :must_be_seen_by,
+      :intake_date,
       language_ids: [],
       user_ids: []
     ).merge(community_id: current_community.id, region_id: current_region.id)

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -171,9 +171,9 @@ class Friend < ApplicationRecord
       ['Border Queue Number (High to Low)', 'border_queue_number_desc'],
       ['Intake Date (Ascending)', 'intake_date_asc'],
       ['Intake Date (Descending)', 'intake_date_desc'],
-      ['Must Be Seen By (Soonest)', 'must_be_seen_by_asc']
+      ['Must Be Seen By (Soonest)', 'must_be_seen_by_asc'],
       ['Date of Entry (Ascending)', 'date_of_entry_asc'],
-      ['Date of Entry (Descending)', 'date_of_entry_desc']
+      ['Date of Entry (Descending)', 'date_of_entry_desc'],
     ]
   end
 

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -136,6 +136,10 @@ class Friend < ApplicationRecord
       order("friends.created_at #{direction}")
     when /^border_queue_number/
       order("friends.border_queue_number #{direction}")
+    when /^intake_date_/
+      order("friends.intake_date #{direction}")
+    when /^must_be_seen_by_/
+      order("friends.must_be_seen_by #{direction}")
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end
@@ -162,7 +166,10 @@ class Friend < ApplicationRecord
       %w[Newest created_at_desc],
       %w[Oldest created_at_asc],
       ['Border Queue Number (Low to High)', 'border_queue_number_asc'],
-      ['Border Queue Number (High to Low)', 'border_queue_number_desc']
+      ['Border Queue Number (High to Low)', 'border_queue_number_desc'],
+      ['Intake Date (Earliest to Latest)', 'intake_date_asc'],
+      ['Intake Date (Latest to Earliest)', 'intake_date_desc'],
+      ['Must Be Seen By (Soonest)', 'must_be_seen_by_asc']
     ]
   end
 

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -1,16 +1,16 @@
 <div class='form_fields_section'>
   <h3>Intake</h3>
   <div class='row form-group'>
-    <%= f.label :must_be_seen_by, 'Must Be Seen By Date', class: 'col-md-2 control-label' %>
-    <div class='col-md-6'>
-      <%= f.date_select :must_be_seen_by, { start_year: 2019, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-    </div>
-  </div>
-
-  <div class='row form-group'>
     <%= f.label :intake_date, 'Intake Date', class: 'col-md-2 control-label' %>
     <div class='col-md-6'>
-      <%= f.date_select :intake_date, { start_year: 2018, end_year: 2019, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+      <%= f.text_field :intake_date, class: 'datepicker' %>
+    </div>
+  </div>
+  
+  <div class='row form-group'>
+    <%= f.label :must_be_seen_by, 'Must Be Seen By Date', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.text_field :must_be_seen_by, class: 'datepicker' %>
     </div>
   </div>
 

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -1,6 +1,20 @@
 <div class='form_fields_section'>
   <h3>Intake</h3>
   <div class='row form-group'>
+    <%= f.label :must_be_seen_by, 'Must Be Seen By Date', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :must_be_seen_by, { start_year: 2019, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :intake_date, 'Intake Date', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :intake_date, { start_year: 2018, end_year: 2019, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
     <%= f.label :intake_notes, 'Intake Notes', class: 'col-md-2 control-label' %>
     <div class='col-md-10'>
       <%= f.text_area :intake_notes, class: 'form-control', style: 'height: 200px;' %>

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -1,105 +1,114 @@
-<h3>Intake</h3>
-<div class='row form-group'>
-  <%= f.label :intake_notes, 'Intake Notes', class: 'col-md-2 control-label' %>
-  <div class='col-md-10'>
-    <%= f.text_area :intake_notes, class: 'form-control', style: 'height: 200px;' %>
+<div class='form_fields_section'>
+  <h3>Intake</h3>
+  <div class='row form-group'>
+    <%= f.label :intake_notes, 'Intake Notes', class: 'col-md-2 control-label' %>
+    <div class='col-md-10'>
+      <%= f.text_area :intake_notes, class: 'form-control', style: 'height: 200px;' %>
+    </div>
   </div>
 </div>
 
+<div class='form_fields_section'>
+  <h3>Asylum</h3>
+  <div class='row form-group'>
+    <%= f.label :asylum_status, 'Status', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.select :asylum_status, options_for_select(Friend::ASYLUM_STATUSES, @friend.asylum_status), {include_blank: true}, {class: 'form-control'} %>
+    </div>
+  </div>
 
-<h3>Asylum</h3>
-<div class='row form-group'>
-  <%= f.label :asylum_status, 'Status', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.select :asylum_status, options_for_select(Friend::ASYLUM_STATUSES, @friend.asylum_status), {include_blank: true}, {class: 'form-control'} %>
+  <div class='row form-group'>
+    <%= f.label :date_asylum_application_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :date_asylum_application_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :asylum_notes, 'Notes', class: 'col-md-2 control-label' %>
+    <div class='col-md-10'>
+      <%= f.text_area :asylum_notes, class: 'form-control', style: 'height: 200px;' %>
+    </div>
   </div>
 </div>
 
-<div class='row form-group'>
-  <%= f.label :date_asylum_application_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.date_select :date_asylum_application_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+<div class='form_fields_section'>
+  <h3>SIJS</h3>
+
+  <div class='row form-group'>
+    <%= f.label :sijs_status, 'Status', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.select :sijs_status, options_for_select(Friend::SIJS_STATUSES, @friend.sijs_status), {include_blank: true}, {class: 'form-control'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :sijs_lawyer, 'SIJS Lawyer', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= collection_select(:friend, :sijs_lawyer, current_region.lawyers.order('organization asc'), :id, :name_and_organization, {include_blank: true}, {class: 'form-control chzn-select'}) %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :date_sijs_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :date_sijs_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :sijs_notes, 'Notes', class: 'col-md-2 control-label' %>
+    <div class='col-md-10'>
+      <%= f.text_area :sijs_notes, class: 'form-control', style: 'height: 200px;' %>
+    </div>
   </div>
 </div>
 
-<div class='row form-group'>
-  <%= f.label :asylum_notes, 'Notes', class: 'col-md-2 control-label' %>
-  <div class='col-md-10'>
-    <%= f.text_area :asylum_notes, class: 'form-control', style: 'height: 200px;' %>
+<div class='form_fields_section'>
+  <h3>Work Authorization</h3>
+  <div class='row form-group'>
+    <%= f.label :work_authorization_status, 'Status', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.select :work_authorization_status, options_for_select(Friend::WORK_AUTHORIZATION_STATUSES, @friend.work_authorization_status), {include_blank: true}, {class: 'form-control'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :date_eligible_to_apply_for_work_authorization, 'Date Eligible to Apply', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :date_eligible_to_apply_for_work_authorization, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :date_work_authorization_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :date_work_authorization_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :work_authorization_notes, 'Notes', class: 'col-md-2 control-label' %>
+    <div class='col-md-10'>
+      <%= f.text_area :work_authorization_notes, class: 'form-control', style: 'height: 200px;' %>
+    </div>
   </div>
 </div>
 
-<h3>SIJS</h3>
-
-<div class='row form-group'>
-  <%= f.label :sijs_status, 'Status', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.select :sijs_status, options_for_select(Friend::SIJS_STATUSES, @friend.sijs_status), {include_blank: true}, {class: 'form-control'} %>
+<div class='form_fields_section'>
+  <h3>FOIA Request</h3>
+  <div class='row form-group'>
+    <%= f.label :date_foia_request_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.date_select :date_foia_request_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+    </div>
   </div>
-</div>
 
-<div class='row form-group'>
-  <%= f.label :sijs_lawyer, 'SIJS Lawyer', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= collection_select(:friend, :sijs_lawyer, current_region.lawyers.order('organization asc'), :id, :name_and_organization, {include_blank: true}, {class: 'form-control chzn-select'}) %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :date_sijs_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.date_select :date_sijs_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :sijs_notes, 'Notes', class: 'col-md-2 control-label' %>
-  <div class='col-md-10'>
-    <%= f.text_area :sijs_notes, class: 'form-control', style: 'height: 200px;' %>
-  </div>
-</div>
-
-<h3>Work Authorization</h3>
-<div class='row form-group'>
-  <%= f.label :work_authorization_status, 'Status', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.select :work_authorization_status, options_for_select(Friend::WORK_AUTHORIZATION_STATUSES, @friend.work_authorization_status), {include_blank: true}, {class: 'form-control'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :date_eligible_to_apply_for_work_authorization, 'Date Eligible to Apply', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.date_select :date_eligible_to_apply_for_work_authorization, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :date_work_authorization_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.date_select :date_work_authorization_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :work_authorization_notes, 'Notes', class: 'col-md-2 control-label' %>
-  <div class='col-md-10'>
-    <%= f.text_area :work_authorization_notes, class: 'form-control', style: 'height: 200px;' %>
-  </div>
-</div>
-
-<h3>FOIA Request</h3>
-<div class='row form-group'>
-  <%= f.label :date_foia_request_submitted, 'Date Submitted', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.date_select :date_foia_request_submitted, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
-  <%= f.label :foia_request_notes, 'Notes', class: 'col-md-2 control-label' %>
-  <div class='col-md-10'>
-    <%= f.text_area :foia_request_notes, class: 'form-control', style: 'height: 200px;' %>
+  <div class='row form-group'>
+    <%= f.label :foia_request_notes, 'Notes', class: 'col-md-2 control-label' %>
+    <div class='col-md-10'>
+      <%= f.text_area :foia_request_notes, class: 'form-control', style: 'height: 200px;' %>
+    </div>
   </div>
 </div>
 <br>

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -1,3 +1,12 @@
+<h3>Intake</h3>
+<div class='row form-group'>
+  <%= f.label :intake_notes, 'Intake Notes', class: 'col-md-2 control-label' %>
+  <div class='col-md-10'>
+    <%= f.text_area :intake_notes, class: 'form-control', style: 'height: 200px;' %>
+  </div>
+</div>
+
+
 <h3>Asylum</h3>
 <div class='row form-group'>
   <%= f.label :asylum_status, 'Status', class: 'col-md-2 control-label' %>

--- a/db/migrate/20190410004748_add_intake_notes_to_friends.rb
+++ b/db/migrate/20190410004748_add_intake_notes_to_friends.rb
@@ -1,0 +1,5 @@
+class AddIntakeNotesToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :intake_notes, :text
+  end
+end

--- a/db/migrate/20190410013846_add_intake_dates_to_friends.rb
+++ b/db/migrate/20190410013846_add_intake_dates_to_friends.rb
@@ -1,0 +1,6 @@
+class AddIntakeDatesToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :intake_date, :datetime
+    add_column :friends, :must_be_seen_by, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_10_004748) do
+ActiveRecord::Schema.define(version: 2019_04_10_013846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,8 @@ ActiveRecord::Schema.define(version: 2019_04_10_004748) do
     t.string "city"
     t.string "jail_id"
     t.text "intake_notes"
+    t.datetime "intake_date"
+    t.datetime "must_be_seen_by"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_23_213034) do
+ActiveRecord::Schema.define(version: 2019_04_10_004748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,6 +205,7 @@ ActiveRecord::Schema.define(version: 2019_02_23_213034) do
     t.integer "border_queue_number"
     t.string "city"
     t.string "jail_id"
+    t.text "intake_notes"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"
   end


### PR DESCRIPTION
Save Friend A (just dates), verify saved:
<img width="1507" alt="Screenshot 2019-04-09 22 28 45" src="https://user-images.githubusercontent.com/1188988/55847344-e7ed2f80-5b16-11e9-879c-9fc38eff0ef9.png">

Save Friend B (dates & notes), verify saved when refreshing:
<img width="1507" alt="Screenshot 2019-04-09 22 28 52" src="https://user-images.githubusercontent.com/1188988/55847371-06532b00-5b17-11e9-8f18-64d1c3f7d726.png">

Sort by "Must be seen by (soonest)" (Santiago 1st, Nikola 2nd):
<img width="1505" alt="Screenshot 2019-04-09 22 30 31" src="https://user-images.githubusercontent.com/1188988/55847415-284cad80-5b17-11e9-9304-5d649d81eaf5.png">

Sort by "Intake Date" (Nikola 1st, Santiago 2nd):
<img width="1505" alt="Screenshot 2019-04-09 22 30 31" src="https://user-images.githubusercontent.com/1188988/55847439-40243180-5b17-11e9-8925-689a5b163ff4.png">

## Why is this PR needed?

Admins need to be able to add intake notes, must seen by date, and intake date to friends' pages.

Also they can now sort by the 2 dates. (figured this should all be 1 pull request because of the db changes)

## Solution

Created an add migration, added field to form, permitted field to be written in controller, added some spacing.

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/208
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/207
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/206