### PR TITLE
Rsl map less

### DIFF
--- a/app/controllers/regional_admin/friends_controller.rb
+++ b/app/controllers/regional_admin/friends_controller.rb
@@ -28,7 +28,7 @@ class RegionalAdmin::FriendsController < RegionalAdminController
   end
 
   def user_friend_associations_params
-    persisted_lawyer_ids = @friend.remote_clinic_lawyers.map(&:id)
+    persisted_lawyer_ids = @friend.remote_clinic_lawyers.pluck(:id)
     lawyer_ids_params = friend_params[:user_ids].map { |id| id.to_i if id.present? }.compact
     added_lawyer_ids = lawyer_ids_params - persisted_lawyer_ids
     removed_lawyer_ids = persisted_lawyer_ids - lawyer_ids_params

--- a/app/controllers/regional_admin/remote_lawyers_controller.rb
+++ b/app/controllers/regional_admin/remote_lawyers_controller.rb
@@ -27,7 +27,7 @@ class RegionalAdmin::RemoteLawyersController < AdminController
   private
 
   def user_friend_associations_params
-    persisted_friend_ids = @remote_lawyer.remote_clinic_friends.map(&:id)
+    persisted_friend_ids = @remote_lawyer.remote_clinic_friends.pluck(:id)
     friend_ids = remote_lawyer_params[:friend_ids]
     friend_ids_params = friend_ids ? friend_ids.map { |id| id.to_i if id.present? }.compact : []
     added_friend_ids = friend_ids_params - persisted_friend_ids

--- a/app/mailers/review_mailer.rb
+++ b/app/mailers/review_mailer.rb
@@ -3,14 +3,14 @@ class ReviewMailer < ApplicationMailer
 
   def review_needed_email(draft)
     @draft = draft
-    emails = draft.friend.remote_clinic_lawyers.map(&:email)
+    emails = draft.friend.remote_clinic_lawyers.pluck(:email)
     @link_url = remote_clinic_friend_url(draft.friend)
     mail(to: emails, subject: 'Review needed')
   end
 
   def lawyer_assignment_needed_email(draft)
     @draft = draft
-    emails = draft.friend.region.regional_admins.map(&:email)
+    emails = draft.friend.region.regional_admins.pluck(:email)
     @link_url = regional_admin_region_friend_url(draft.friend.region, draft.friend)
     mail(to: emails, subject: 'Lawyer assignment needed')
   end
@@ -18,7 +18,7 @@ class ReviewMailer < ApplicationMailer
   def changes_requested_email(review)
     @review = review
     friend = review.draft.friend
-    emails = friend.users.where(user_friend_associations: { remote: false }).map(&:email).flatten
+    emails = friend.users.where(user_friend_associations: { remote: false }).pluck(:email)
     @link_url = community_friend_draft_review_url(friend.community.slug, friend, review.draft, review)
     mail(to: emails, subject: "Changes requested on #{friend.first_name}'s application")
   end
@@ -26,7 +26,7 @@ class ReviewMailer < ApplicationMailer
   def application_approved_email(application)
     @application = application
     friend = application.friend
-    emails = friend.users.where(user_friend_associations: { remote: false }).map(&:email).flatten
+    emails = friend.users.where(user_friend_associations: { remote: false }).pluck(:email)
     @link_url = community_friend_url(friend.community.slug, friend)
     mail(to: emails, subject: "A draft of #{friend.first_name}'s application has been approved ")
   end

--- a/app/views/activities/_accompaniment_modal.html.erb
+++ b/app/views/activities/_accompaniment_modal.html.erb
@@ -19,7 +19,7 @@
               <strong>Accompaniment Leaders:  </strong>
               <%= render 'shared/scoped_activity_users_details', activity: activity, scope: 'accompaniment_leader' %>
             <% end %>
-            <strong>Volunteers:  </strong><%= activity.users.volunteer.map(&:first_name).to_sentence %>
+            <strong>Volunteers:  </strong><%= activity.users.volunteer.pluck(:first_name).to_sentence %>
             <div><em><%= volunteers_needed(activity) %></em></div>
             <% if current_user.attending?(activity) || !activity.accompaniment_limit_met? %>
               <%= form_for [current_community, accompaniment] do |f| %>

--- a/app/views/admin/cohorts/_friend_assignment.html.erb
+++ b/app/views/admin/cohorts/_friend_assignment.html.erb
@@ -1,6 +1,6 @@
 <h3>Friends Assigned</h3>
 <%= form_for [current_community, :admin, cohort, FriendCohortAssignment.new], remote: true do |f| %>
-  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends.where('clinic_wait_list_priority IS NOT NULL'), 'id', 'name_and_clinic_priority', disabled: FriendCohortAssignment.all.map(&:friend_id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends.where('clinic_wait_list_priority IS NOT NULL'), 'id', 'name_and_clinic_priority', disabled: FriendCohortAssignment.all.pluck(:friend_id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
 <% end %>
 <br>
 <table class='table table-bordered'>

--- a/app/views/admin/events/_friend_attendance.html.erb
+++ b/app/views/admin/events/_friend_attendance.html.erb
@@ -1,6 +1,6 @@
 <h3>Friends Attending</h3>
 <%= form_for [current_community, :admin, event, FriendEventAttendance.new], remote: true do |f| %>
-  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends, 'id', 'name', disabled: attending_friends.map(&:id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends, 'id', 'name', disabled: attending_friends.pluck(:id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
 <% end %>
 <br>
 <table class='table table-bordered'>

--- a/app/views/admin/friends/_access_form_fields.html.erb
+++ b/app/views/admin/friends/_access_form_fields.html.erb
@@ -4,7 +4,7 @@
   <%= fields_for(@friend.user_friend_associations.build) do |fl| %>
     <%= fl.label :users,'Volunteers with Access', class: 'col-md-2 control-label' %>
     <div class='col-md-6'>
-      <%= collection_select(:friend, :user_ids, current_community.users, :id, :name, {selected: @friend.volunteers_with_access.map(&:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+      <%= collection_select(:friend, :user_ids, current_community.users, :id, :name, {selected: @friend.volunteers_with_access.pluck(:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
     </div>
   <% end %>
 </div>

--- a/app/views/friends/_access.html.erb
+++ b/app/views/friends/_access.html.erb
@@ -3,7 +3,7 @@
     <%= fields_for(@friend.user_friend_associations.build) do |fl| %>
       <%= fl.label :users,'Volunteers with Access', class: 'col-md-3 control-label' %>
       <div class='col-md-9'>
-        <%= collection_select(:friend, :user_ids, current_community.users, :id, :name, {selected: @friend.volunteers_with_access.map(&:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control', id: 'volunteer-shares-friend'}) %>
+        <%= collection_select(:friend, :user_ids, current_community.users, :id, :name, {selected: @friend.volunteers_with_access.pluck(:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control', id: 'volunteer-shares-friend'}) %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/friends/_info.html.erb
+++ b/app/views/friends/_info.html.erb
@@ -8,7 +8,7 @@
 <p><strong>Email:  </strong><%= friend.email %></p>
 <p><strong>Gender:  </strong><%= friend.gender.try(:humanize) %></p>
 <p><strong>Ethnicity:  </strong><%= friend.ethnicity.try(:humanize) %></p>
-<p><strong>Languages:  </strong><%= friend.languages.map(&:name).to_sentence %></p>
+<p><strong>Languages:  </strong><%= friend.languages.pluck(:name).to_sentence %></p>
 <p><strong>Country of Origin:  </strong><%= Country.find(friend.country_id).name if friend.country_id.present? %></p>
 <p><strong>Zip Code: </strong><%= friend.zip_code if friend.zip_code.present? %></p>
 <p><strong>City: </strong><%= friend.city %></p>
@@ -36,7 +36,7 @@
       <strong>What:  </strong><%= activity.activity_type.name.titlecase %><br>
       <strong>When:  </strong><%= activity.occur_at.strftime("%I:%M %p, %A, %B %-d, %Y") %><br>
       <strong>Where:  </strong><%= activity.location.name  if activity.location.present? %><br>
-      <strong>Volunteers:  </strong><%= activity.users.map(&:first_name).to_sentence %>
+      <strong>Volunteers:  </strong><%= activity.users.pluck(:first_name).to_sentence %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/regional_admin/friends/show.html.erb
+++ b/app/views/regional_admin/friends/show.html.erb
@@ -57,7 +57,7 @@
   <%= form_for [:regional_admin, current_region, @friend] do |f| %>
     <%= fields_for @friend.user_friend_associations do |fl| %>
       <div class='col-md-6'>
-        <%= collection_select(:friend, :user_ids, User.remote_lawyers, :id, :name, {selected: @friend.remote_clinic_lawyers.map(&:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+        <%= collection_select(:friend, :user_ids, User.remote_lawyers, :id, :name, {selected: @friend.remote_clinic_lawyers.pluck(:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
       </div>
     <% end %>
 

--- a/app/views/regional_admin/remote_lawyers/_form.html.erb
+++ b/app/views/regional_admin/remote_lawyers/_form.html.erb
@@ -79,7 +79,7 @@
         <%= fields_for @remote_lawyer.user_friend_associations do |fl| %>
           <%= f.label 'Assigned Friends', class: 'col-md-2 control-label' %>
           <div class='col-md-6'>
-            <%= collection_select(:remote_lawyer, :friend_ids, Friend.with_active_applications, :id, :name, {selected: @remote_lawyer.remote_clinic_friends.map(&:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+            <%= collection_select(:remote_lawyer, :friend_ids, Friend.with_active_applications, :id, :name, {selected: @remote_lawyer.remote_clinic_friends.pluck(:id)}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
           </div>
         <% end %>
       </div>

--- a/app/views/remote_clinic/friends/index.html.erb
+++ b/app/views/remote_clinic/friends/index.html.erb
@@ -1,7 +1,7 @@
 <h2>Friends with Active Applications</h2>
 
 <div id='friends-with-active-applications'>
-  <% @friends.map do |friend| %>
+  <% @friends.each do |friend| %>
     <% friendship = current_user.relationship(friend) %>
     <div class='row'>
       <div class='col-md-6'>


### PR DESCRIPTION
## Why is this PR needed?

Using `Enumerable#map` instantiates objects we don't always need. These places look like we could just `pluck` to get values directly from db and save some.

## Solution

☝️ 
