### PR TITLE
update ruby version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.1
+FROM ruby:2.6.2
 
 RUN apt-get update -qq \
 	&& apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Why is this PR needed?

Currently, the ruby version specified in the DockerFile is 2.6.1 and the ruby version specified in the gem file is 2.6.2.

## Solution

Just a one line change to update the version.

### Link to associated issue: 

No issue - discussed in write/speak/code slack
