### PR TITLE
Update invitation instructions to include community name

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome New Sanctuary Coalition!</p>
+<p>Welcome New Sanctuary Coalition (<%= @resource.community.name.upcase %>)!</p>
 
 <p>Please follow this link to accept your invitation to the New Sanctuary Coalition software: <%= link_to accept_user_community_invitation_url(@resource.community.slug, invitation_token: @token), accept_user_community_invitation_url(@resource.community.slug, invitation_token: @token) %></p>
 

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome New Sanctuary Coalition (<%= @resource.community.name.upcase %>)!</p>
+<p>Welcome New Sanctuary Coalition (<%= @resource.community.name.upcase %>) Volunteer!</p>
 
 <p>Please follow this link to accept your invitation to the New Sanctuary Coalition software: <%= link_to accept_user_community_invitation_url(@resource.community.slug, invitation_token: @token), accept_user_community_invitation_url(@resource.community.slug, invitation_token: @token) %></p>
 

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,4 +1,4 @@
-Welcome New Sanctuary Coalition Volunteer!
+Welcome New Sanctuary Coalition (<%= @resource.community.name.upcase %>) Volunteer!
 
 Please follow this link to accept your invitation to the New Sanctuary Coalition software: <%= accept_user_community_invitation_url(@resource.community.slug, invitation_token: @token) %>
 


### PR DESCRIPTION
## Why is this PR needed?
To address https://github.com/CZagrobelny/new_sanctuary_asylum/issues/242, this PR adds the community name that a user is being invited to.

## Solution
- Adds community name to the instruction text.

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/242