### PR TITLE
239 prevent data entry users from editing user roles

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -50,7 +50,8 @@ class Admin::UsersController < AdminController
 
   def update
     @user = current_community.users.find(params[:id])
-    if @user.update(user_params)
+
+    if @user.update(current_user.admin? ? user_params : user_params_excluding_role)
       redirect_to community_admin_users_path(current_community.slug)
     else
       render 'edit'
@@ -83,6 +84,20 @@ class Admin::UsersController < AdminController
       :phone,
       :volunteer_type,
       :role,
+      :pledge_signed,
+      :signed_guidelines,
+      :attended_training,
+      :remote_clinic_lawyer
+    )
+  end
+
+  def user_params_excluding_role
+    params.require(:user).permit(
+      :first_name,
+      :last_name,
+      :email,
+      :phone,
+      :volunteer_type,
       :pledge_signed,
       :signed_guidelines,
       :attended_training,

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -38,12 +38,14 @@
       </div>
     </div>
 
-    <div class='form-group'>
-      <%= f.label :role, class: 'col-md-2 control-label required' %>
-      <div class='col-md-6'>
-        <%= f.select :role, current_community.primary? ? User::PRIMARY_ROLES : User::NON_PRIMARY_ROLES, {}, {class: 'form-control input-md'} %>
+    <% if current_user.admin? %> 
+      <div class='form-group'>
+        <%= f.label :role, class: 'col-md-2 control-label required' %>
+        <div class='col-md-6'>
+          <%= f.select :role, current_community.primary? ? User::PRIMARY_ROLES : User::NON_PRIMARY_ROLES, {}, {class: 'form-control input-md'} %>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <div class='form-group'>
       <div class='col-md-6 col-md-offset-2'>

--- a/spec/controllers/data_entry_access/users_controller_spec.rb
+++ b/spec/controllers/data_entry_access/users_controller_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe Admin::UsersController, type: :controller do
+  let!(:community) { create :community }
+  let!(:data_entry_user) { create :user, community: community, role: 'data_entry' }
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+    allow(controller).to receive(:current_user).and_return(data_entry_user)
+  end
+
+  describe "PUT #update" do
+    context 'when the user has an active time slot' do
+      before do
+        AccessTimeSlot.create(grantee_id: data_entry_user.id,
+          grantor_id: 100,
+          community_id: data_entry_user.community.id,
+          use: 'data_entry',
+          start_time: 1.hour.ago,
+          end_time: 1.hour.from_now
+        )
+      end
+      let!(:user) {create :user, community: community, role: "admin", first_name: "Elizabeth"}
+      it 'does NOT update user role but does update other attributes' do
+        user.first_name = "Jane"
+        user.role = "data_entry"
+        put :update, params: {
+          community_slug: community.slug, 
+          id: user.id, 
+          user: user.attributes
+        }
+        expect(user.reload.role).to eq "admin"
+        expect(user.reload.first_name).to eq "Jane"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why is this PR needed?

This is a solution for Issue #239 .  Currently, data entry users with an active time slot can change the role of other users (to admin, for example)

## Solution

This work hides the control in the interface for data_entry users.  (Actually, it changes it so it is only displayed for admins.)

It also updates the controller to omit the `role` param when current_user is not an admin, and writes a test confirming this behavior for data entry users.

### Link to associated issue: 

#239 