### PR TITLE
Added volunteer language select feature, updated fields accordingly

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,9 +2,6 @@ class Admin::UsersController < AdminController
   def index
     @filterrific = initialize_filterrific(User,
                                           params[:filterrific],
-                                          select_options: {
-                                            filter_volunteer_type: volunteer_type_options
-                                          },
                                           persistence_id: false)
 
     @filterrific_role = initialize_filterrific(User,
@@ -61,12 +58,6 @@ class Admin::UsersController < AdminController
 
   private
 
-  def volunteer_type_options
-    User.volunteer_types.keys.map do |volunteer_type|
-      [volunteer_type.humanize, volunteer_type]
-    end
-  end
-
   def role_options
     User.roles.keys.map do |role_type|
       [role_type.humanize, role_type]
@@ -83,7 +74,6 @@ class Admin::UsersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :role,
       :pledge_signed,
       :signed_guidelines,
@@ -99,17 +89,15 @@ class Admin::UsersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :pledge_signed,
       :signed_guidelines,
       :attended_training,
-      :remote_clinic_lawyer
+      :remote_clinic_lawyer,
+      language_ids: [],
     )
   end
 
   def user_index_scope
-    scope = current_community.users
-    scope = scope.for_volunteer_type(params[:volunteer_type]) if params[:volunteer_type].present?
-    scope
+    current_community.users
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -88,7 +88,8 @@ class Admin::UsersController < AdminController
       :pledge_signed,
       :signed_guidelines,
       :attended_training,
-      :remote_clinic_lawyer
+      :remote_clinic_lawyer,
+      language_ids: [],
     )
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -30,16 +30,18 @@ class InvitationsController < Devise::InvitationsController
   end
 
   def update_sanitized_params
-    devise_parameter_sanitizer.permit(:accept_invitation,
-                                      keys: %i[first_name
-                                               last_name
-                                               phone
-                                               password
-                                               password_confirmation
-                                               remote_clinic_lawyer
-                                               invitation_token
-                                               volunteer_type
-                                               pledge_signed])
+    devise_parameter_sanitizer.permit(:accept_invitation) do |user|
+      user.permit(:first_name,
+                  :last_name,
+                  :phone,
+                  :password,
+                  :password_confirmation,
+                  :remote_clinic_lawyer,
+                  :invitation_token,
+                  :volunteer_type,
+                  :pledge_signed,
+                  language_ids: [])
+    end
   end
 
   def allow_devise_params

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -38,7 +38,6 @@ class InvitationsController < Devise::InvitationsController
                   :password_confirmation,
                   :remote_clinic_lawyer,
                   :invitation_token,
-                  :volunteer_type,
                   :pledge_signed,
                   language_ids: [])
     end

--- a/app/controllers/regional_admin/remote_lawyers_controller.rb
+++ b/app/controllers/regional_admin/remote_lawyers_controller.rb
@@ -55,12 +55,12 @@ class RegionalAdmin::RemoteLawyersController < AdminController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :role,
       :pledge_signed,
       :signed_guidelines,
       :remote_clinic_lawyer,
-      friend_ids: []
+      friend_ids: [],
+      language_ids: []
     )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,6 @@ class UsersController < ApplicationController
       :last_name,
       :email,
       :phone,
-      :volunteer_type,
       :pledge_signed,
       :remote_clinic_lawyer,
       language_ids: [],

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,8 @@ class UsersController < ApplicationController
       :phone,
       :volunteer_type,
       :pledge_signed,
-      :remote_clinic_lawyer
+      :remote_clinic_lawyer,
+      language_ids: [],
     )
   end
 

--- a/app/helpers/accompaniment_helper.rb
+++ b/app/helpers/accompaniment_helper.rb
@@ -2,7 +2,9 @@ module AccompanimentHelper
   def accompaniment_user_details(accompaniment)
     user = accompaniment.user
     [user.phone, user.email].tap do |details|
-      details << user.volunteer_type.humanize.titleize if user.volunteer?
+      user.languages.each do |language|
+        details << language.name.humanize.titleize if user.volunteer?
+      end
       details << accompaniment.availability_notes if accompaniment.availability_notes.present?
     end
   end

--- a/app/helpers/accompaniment_helper.rb
+++ b/app/helpers/accompaniment_helper.rb
@@ -1,11 +1,14 @@
 module AccompanimentHelper
   def accompaniment_user_details(accompaniment)
     user = accompaniment.user
+    languages = user.languages.map { |language| language.name.titleize }
     [user.phone, user.email].tap do |details|
-      user.languages.each do |language|
-        details << language.name.humanize.titleize if user.volunteer?
+      if languages.present?
+        details << "Languages: #{languages.join(', ')}"
       end
-      details << accompaniment.availability_notes if accompaniment.availability_notes.present?
+      if accompaniment.availability_notes.present?
+        details << "Notes: #{accompaniment.availability_notes}"
+      end
     end
   end
 

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,4 +1,7 @@
 class Language < ApplicationRecord
   has_many :friend_languages, dependent: :destroy
   has_many :friends, through: :friend_languages
+  has_many :volunteer_languages, dependent: :destroy
+  has_many :users, through: :volunteer_languages
+  
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,19 +17,24 @@ class User < ApplicationRecord
   validates_inclusion_of :pledge_signed, in: [true]
 
   belongs_to :community
-  has_many :user_regions
-  has_many :regions, through: :user_regions
-  has_many :user_friend_associations, dependent: :destroy
-  has_many :friends, through: :user_friend_associations
-  has_many :user_draft_associations, dependent: :destroy
-  has_many :drafts, through: :user_draft_associations
-  has_many :accompaniments, dependent: :destroy
-  has_many :user_event_attendances, dependent: :destroy
-  has_many :accompaniment_reports, dependent: :destroy
-  has_many :reviews
-  has_many :releases
   has_many :access_time_slots, foreign_key: :grantee_id, class_name: 'AccessTimeSlot', dependent: :restrict_with_error
   has_many :access_time_slots_granted, foreign_key: :grantor_id, class_name: 'AccessTimeSlot', dependent: :restrict_with_error
+  has_many :accompaniments, dependent: :destroy
+  has_many :accompaniment_reports, dependent: :destroy
+  has_many :user_draft_associations, dependent: :destroy
+  has_many :drafts, through: :user_draft_associations
+  has_many :user_friend_associations, dependent: :destroy
+  has_many :friends, through: :user_friend_associations
+  has_many :volunteer_languages, dependent: :destroy
+  has_many :languages, through: :volunteer_languages
+  has_many :user_regions
+  has_many :regions, through: :user_regions
+  has_many :releases
+  has_many :reviews
+  has_many :user_event_attendances, dependent: :destroy
+
+ 
+
 
   accepts_nested_attributes_for :user_friend_associations, allow_destroy: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   enum role: %i[volunteer accompaniment_leader admin data_entry]
   enum volunteer_type: %i[english_speaking spanish_interpreter lawyer]
 
-  validates :first_name, :last_name, :email, :phone, :volunteer_type, :community_id, presence: true
+  validates :first_name, :last_name, :email, :phone, :community_id, presence: true
   validates :email, uniqueness: true
   validates_inclusion_of :pledge_signed, in: [true]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,6 @@ class User < ApplicationRecord
   attr_reader :raw_invitation_token
 
   enum role: %i[volunteer accompaniment_leader admin data_entry]
-  enum volunteer_type: %i[english_speaking spanish_interpreter lawyer]
 
   validates :first_name, :last_name, :email, :phone, :community_id, presence: true
   validates :email, uniqueness: true
@@ -33,7 +32,7 @@ class User < ApplicationRecord
   has_many :reviews
   has_many :user_event_attendances, dependent: :destroy
 
- 
+
 
 
   accepts_nested_attributes_for :user_friend_associations, allow_destroy: true
@@ -45,7 +44,6 @@ class User < ApplicationRecord
       filter_first_name
       filter_last_name
       filter_email
-      filter_volunteer_type
       filter_role
     ]
   )
@@ -53,10 +51,6 @@ class User < ApplicationRecord
   def remote_clinic_friends
     friends.where(user_friend_associations: { remote: true })
   end
-
-  scope :filter_volunteer_type, ->(volunteer_type) {
-    where(volunteer_type: volunteer_type)
-  }
 
   scope :filter_role, ->(role) {
     where(role: role)

--- a/app/models/volunteer_language.rb
+++ b/app/models/volunteer_language.rb
@@ -1,0 +1,4 @@
+class VolunteerLanguage < ApplicationRecord
+belongs_to :user
+  belongs_to :language
+end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -32,13 +32,6 @@
     </div>
 
     <div class='form-group'>
-      <%= f.label :volunteer_type, 'Type', class: 'col-md-2 control-label required' %>
-      <div class='col-md-6'>
-        <%= f.select :volunteer_type, User.volunteer_types.map {|k, v| [k.humanize.titleize, k]}, {prompt: "Select"}, { class: 'form-control input-md'} %>
-      </div>
-    </div>
-
-    <div class='form-group'>
       <%= fields_for(@user.languages.build) do |fl| %>
         <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>
         <div class='col-md-6'>

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -38,6 +38,15 @@
       </div>
     </div>
 
+    <div class='form-group'>
+      <%= fields_for(@user.languages.build) do |fl| %>
+        <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>
+        <div class='col-md-6'>
+          <%= collection_select(:user, :language_ids, Language.all, :id, :name, {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+        </div>
+      <% end %>
+    </div>
+
     <% if current_user.admin? %> 
       <div class='form-group'>
         <%= f.label :role, class: 'col-md-2 control-label required' %>

--- a/app/views/admin/users/_list.html.erb
+++ b/app/views/admin/users/_list.html.erb
@@ -11,8 +11,7 @@
         <th>Last Name</th>
         <th>Email</th>
         <th>Phone Number</th>
-        <th>Volunteer Type</th>
-        <th>Admin?</th>
+        <th>Role</th>
         <th>Created At</th>
         <th>Actions</th>
       </tr>
@@ -25,8 +24,7 @@
           <td><%= user.last_name %></td>
           <td><%= user.email %></td>
           <td><%= user.phone %></td>
-          <td><%= user.volunteer_type.try(:titleize) %></td>
-          <td><%= user.admin? ? 'YES' : 'NO' %></td>
+          <td><%= user.role.try(:titlecase) %></td>
           <td><%= user.created_at.strftime('%m/%d/%y') %></td>
           <td>
             <div class='btn-group'>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,15 +18,7 @@
       <%= f.label :filter_email, 'Email' %>
       <%= f.text_field(:filter_email, class: 'form-control') %>
     </div>
-    <div class='form-group col-md-3'>
-        <%= f.label :filter_volunteer_type, 'Volunteer Type' %>
-        <%= f.select(
-          :filter_volunteer_type, 
-          @filterrific.select_options[:filter_volunteer_type], 
-          { include_blank: '- Any -' }, 
-          { class: 'form-control' },
-        ) %>
-    </div>
+
     <div class='form-group col-md-3'>
         <%= f.label :filter_role, 'Role' %>
         <%= f.select(

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -27,13 +27,6 @@
       </div>
 
       <div class='row form-group'>
-        <%= f.label :volunteer_type, 'Type', class: 'col-md-2 control-label required' %>
-        <div class='col-md-6'>
-          <%= f.select :volunteer_type, User.volunteer_types.map {|k, v| [k.humanize.titleize, k]}, {prompt: "Select"}, { class: 'form-control input-md'} %>
-        </div>
-      </div>
-
-      <div class='row form-group'>
         <%= fields_for(@user.languages.build) do |fl| %>
           <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>
           <div class='col-md-6'>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -33,6 +33,15 @@
         </div>
       </div>
 
+      <div class='row form-group'>
+        <%= fields_for(@user.languages.build) do |fl| %>
+          <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>
+          <div class='col-md-6'>
+            <%= collection_select(:user, :language_ids, Language.all, :id, :name, {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+          </div>
+        <% end %>
+      </div>
+
       <div class="row form-group">
         <%= f.label :password, class: 'col-md-2 control-label required' %>
         <div class='col-md-6'>

--- a/app/views/regional_admin/remote_lawyers/_form.html.erb
+++ b/app/views/regional_admin/remote_lawyers/_form.html.erb
@@ -32,13 +32,6 @@
     </div>
 
     <div class='form-group'>
-      <%= f.label :volunteer_type, 'Type', class: 'col-md-2 control-label required' %>
-      <div class='col-md-6'>
-        <%= f.select :volunteer_type, User.volunteer_types.map {|k, v| [k.humanize.titleize, k]}, {prompt: "Select"}, { class: 'form-control input-md'} %>
-      </div>
-    </div>
-
-    <div class='form-group'>
       <%= f.label :role, class: 'col-md-2 control-label required' %>
       <div class='col-md-6'>
         <%= f.select :role, User::NON_PRIMARY_ROLES, {}, {class: 'form-control input-md'} %>

--- a/app/views/regional_admin/remote_lawyers/index.html.erb
+++ b/app/views/regional_admin/remote_lawyers/index.html.erb
@@ -8,8 +8,7 @@
         <th>Last Name</th>
         <th>Email</th>
         <th>Phone Number</th>
-        <th>Type</th>
-        <th>Admin?</th>
+        <th>Role</th>
         <th>Created</th>
         <th>Actions</th>
       </tr>
@@ -22,8 +21,7 @@
           <td><%= lawyer.last_name %></td>
           <td><%= lawyer.email %></td>
           <td><%= lawyer.phone %></td>
-          <td><%= lawyer.volunteer_type.try(:titleize) %></td>
-          <td><%= lawyer.admin? ? 'YES' : 'NO' %></td>
+          <td><%= lawyer.role.try(:titlecase) %></td>
           <td><%= lawyer.created_at.strftime('%m/%d/%y') %></td>
 
           <td>

--- a/app/views/shared/_scoped_activity_users_details.html.erb
+++ b/app/views/shared/_scoped_activity_users_details.html.erb
@@ -4,7 +4,8 @@
     <li>
       <%= current_user.volunteer? ? accompaniment.user.first_name : accompaniment.user.name %>,
       <i>
-        <%= accompaniment_user_details(accompaniment).join(', ') %>
+        <% details = accompaniment_user_details(accompaniment) %>
+        <%= details[0..1].join(', ') + ', Languages: ' + details[2..details.length].join(', ')%>
       </i>
     </li>
   <% end %>

--- a/app/views/shared/_scoped_activity_users_details.html.erb
+++ b/app/views/shared/_scoped_activity_users_details.html.erb
@@ -4,8 +4,7 @@
     <li>
       <%= current_user.volunteer? ? accompaniment.user.first_name : accompaniment.user.name %>,
       <i>
-        <% details = accompaniment_user_details(accompaniment) %>
-        <%= details[0..1].join(', ') + ', Languages: ' + details[2..details.length].join(', ')%>
+        <%= accompaniment_user_details(accompaniment).join(', ') %>
       </i>
     </li>
   <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -31,14 +31,6 @@
       </div>
     </div>
 
-    <div class='row form-group'>
-      <%= f.label :volunteer_type, 'Type', class: 'col-md-2 control-label required' %>
-      <div class='col-md-6'>
-        <%= f.select :volunteer_type, User.volunteer_types.map {|k, v| [k.humanize.titleize, k]}, {prompt: "Select"}, { class: 'form-control input-md'} %>
-      </div>
-    </div>
-  </div>
-
    <div class='row form-group'>
       <%= fields_for(@user.languages.build) do |fl| %>
         <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -39,6 +39,15 @@
     </div>
   </div>
 
+   <div class='row form-group'>
+      <%= fields_for(@user.languages.build) do |fl| %>
+        <%= fl.label :languages,'Languages', class: 'col-md-2 control-label' %>
+        <div class='col-md-6'>
+          <%= collection_select(:user, :language_ids, Language.all, :id, :name, {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+        </div>
+      <% end %>
+    </div>
+
   <div class='row'>
     <div class='col-md-1 col-md-offset-7'>
       <%= f.submit 'Save', class: 'btn btn-primary' %>

--- a/db/migrate/20190905223234_create_volunteer_languages.rb
+++ b/db/migrate/20190905223234_create_volunteer_languages.rb
@@ -1,0 +1,9 @@
+class CreateVolunteerLanguages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :volunteer_languages do |t|
+      t.integer "user_id", null: false, index: true
+      t.integer "language_id", null: false, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_29_145528) do
+ActiveRecord::Schema.define(version: 2019_09_05_223234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -406,6 +406,15 @@ ActiveRecord::Schema.define(version: 2019_08_29_145528) do
     t.index ["password_changed_at"], name: "index_users_on_password_changed_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
+  end
+
+  create_table "volunteer_languages", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "language_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["language_id"], name: "index_volunteer_languages_on_language_id"
+    t.index ["user_id"], name: "index_volunteer_languages_on_user_id"
   end
 
   add_foreign_key "activities", "activity_types"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,51 +33,51 @@ ActiveRecord::Base.transaction do
                                   primary: true)
 
   # NY Regional admin
-  ny_regional_admin = User.create!(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  ny_regional_admin = User.create!(first_name: 'NY Regional', last_name: 'Admin', email: 'ny_regional_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
   ny_regional_admin.user_regions.create!(region_id: ny_region.id)
 
   ## NYC Users
 
   #Accompaniment Leader User
-  User.create!(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'NYC Accompaniment', last_name: 'Leader', email: 'nyc_accompaniment_leader@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create!(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Volunteer', email: 'nyc_volunteer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create!(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'NYC Community', last_name: 'Admin', email: 'nyc_admin@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
 
   #Remote Clinic Lawyer
-  User.create!(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
+  User.create!(first_name: 'Remote Clinic', last_name: 'Lawyer', email: 'remote_clinic_lawyer@example.com', community_id: nyc_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true, remote_clinic_lawyer: true)
 
   #Some additional NYC volunteer users
   20.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
   end
   Timecop.return
 
   10.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 2, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: nyc_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true, remote_clinic_lawyer: false)
   end
   Timecop.return
   ## Long Island Users
 
   #Accompaniment Leader User
-  User.create!(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 1, pledge_signed: true)
+  User.create!(first_name: 'LI Accompaniment', last_name: 'Leader', email: 'li_accompaniment_leader@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 1, pledge_signed: true)
 
   #Volunteer User
-  User.create!(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Volunteer', email: 'li_volunteer@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
 
   #Admin User
-  User.create!(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 2, pledge_signed: true)
+  User.create!(first_name: 'LI Community', last_name: 'Admin', email: 'li_admin@example.com', community_id: long_island_community.id, phone: '888 888 8888', password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 2, pledge_signed: true)
 
 
   #Some additional Long Island volunteer users
   30.times do |index|
     Timecop.travel(index.days.ago)
-    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, volunteer_type: 1, role: 0, pledge_signed: true)
+    User.create!(first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.safe_email, community_id: long_island_community.id, phone: Faker::PhoneNumber.phone_number, password: 'Password1234', password_confirmation: 'Password1234', invitation_accepted_at: Time.now, role: 0, pledge_signed: true)
   end
   Timecop.return
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     email { Faker::Internet.unique.safe_email }
     phone { Faker::PhoneNumber.phone_number }
-    volunteer_type { 1 }
     password { (Faker::Food.fruits + Faker::PhoneNumber.area_code.to_s + Faker::Food.spice).delete(' ') }
     password_confirmation { password }
     invitation_accepted_at { Time.now }
@@ -40,7 +39,6 @@ FactoryBot.define do
     last_name { nil }
     email { Faker::Internet.unique.safe_email }
     phone { nil }
-    volunteer_type { nil }
     password { nil }
     password_confirmation { nil }
     invitation_accepted_at { nil }

--- a/spec/features/invite_a_new_user_spec.rb
+++ b/spec/features/invite_a_new_user_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe 'Admin invites a new user', type: :feature do
         fill_in 'First Name', with: Faker::Name.first_name
         fill_in 'Last Name', with: Faker::Name.last_name
         fill_in 'Phone', with: '876 765 4455'
-        select 'English Speaking', :from => 'Type'
         fill_in 'Password', with: 'Password1234'
         fill_in 'Password Confirmation', with: 'Password1234'
         check 'user_pledge_signed'

--- a/spec/models/mailers/review_mailer_spec.rb
+++ b/spec/models/mailers/review_mailer_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe ReviewMailer, type: :mailer do
 
   describe 'review_needed_email(draft)' do
     let(:draft) { create :draft, status: :in_review }
-    let(:user) { create :user, volunteer_type: "lawyer" }
-    let(:non_remote_clinic_user) { create :user, volunteer_type: "spanish_interpreter",
-                                          role: "volunteer" }
+    let(:user) { create :user }
+    let(:non_remote_clinic_user) { create :user, role: "volunteer" }
 
 
     subject(:mail) { ReviewMailer.review_needed_email(draft)}
@@ -41,10 +40,8 @@ RSpec.describe ReviewMailer, type: :mailer do
 
   describe 'lawyer_assignment_needed_email(draft)' do
     let(:draft) { create :draft, status: :in_review }
-    let(:admin_user) { create :user, volunteer_type: "spanish_interpreter",
-                                     role: "admin" }
-    let(:non_admin_user) { create :user, volunteer_type: "spanish_interpreter",
-                                         role: "volunteer" }
+    let(:admin_user) { create :user, role: "admin" }
+    let(:non_admin_user) { create :user, role: "volunteer" }
 
     subject(:mail) { ReviewMailer.lawyer_assignment_needed_email(draft)}
 
@@ -83,7 +80,7 @@ RSpec.describe ReviewMailer, type: :mailer do
     let(:draft) { create :draft, status: :changes_requested, friend: friend }
     let(:review) { create :review, draft: draft }
     let(:friend) { create :friend, community: community, region: region }
-    let!(:volunteer) { create :user, volunteer_type: 'english_speaking', community: community }
+    let!(:volunteer) { create :user, community: community }
     let!(:community_admin) { create :user, :community_admin, community: community }
     let!(:regional_admin) { create :user, :regional_admin, community: community }
 
@@ -119,7 +116,7 @@ RSpec.describe ReviewMailer, type: :mailer do
     let(:region) { community.region }
     let(:application) { create :application, friend: friend }
     let(:friend) { create :friend, community: community, region: region }
-    let!(:volunteer) { create :user, volunteer_type: 'english_speaking', community: community }
+    let!(:volunteer) { create :user, community: community }
     let!(:community_admin) { create :user, :community_admin, community: community }
     let!(:regional_admin) { create :user, :regional_admin, community: community }
 

--- a/spec/services/notifications_spec.rb
+++ b/spec/services/notifications_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Notification do
   describe '.draft_for_review(draft: draft)' do
     context 'the friend has a lawyer' do
       let(:draft) { create :draft, status: :in_review }
-      let(:user) { create :user, volunteer_type: "lawyer" }
+      let(:user) { create :user }
 
 
       context 'the friend has a remote lawyer' do


### PR DESCRIPTION
## Why is this PR needed?

Users being able to list languages is more versatile and convenient than asking them to identify as either english speaking or interpreters. 

## Solution

The feature was implemented with the following specifications: 

 - [x] Associations between Languages and Users should be many_to_many, like we are currently doing for Friends and Languages
 - [x] The user form (for both admins editing users and users editing their own profile) should contain a Language field (multi select). 
 - [x] A user accepting an invitation should be able to select their languages (this is a different form than the edit user form). 
 - [x] We also need to replace volunteer_type with languages on this user form:
new_sanctuary_asylum/app/views/regional_admin/remote_lawyers/_form.html.erb
 - [x] Replace all instances where we display volunteer_type with the user's languages
 - [x] Remove the 'Volunteer Type' filter on the Users index page (we don't need to replace this with a Language filter at this moment)

Allowing the devise invitation to save the language_ids parameter required the use of do block syntax in the invitations controller:

```ruby 
#app/controllers/invitations_controller.rb

def update_sanitized_params
    devise_parameter_sanitizer.permit(:accept_invitation) do |user|
      user.permit(:first_name,
                  :last_name,
                  :phone,
                  :password,
                  :password_confirmation,
                  :remote_clinic_lawyer,
                  :invitation_token,
                  :volunteer_type,
                  :pledge_signed,
                  language_ids: [])
    end
  end
```

has_many relations were also alphabetized in the users controller for ease of use. 

### Link to associated issue: 

https://github.com/CZagrobelny/new_sanctuary_asylum/issues/245
