### PR TITLE
Updated Gemfile to leverage Ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
-# Make sure to bump .ruby-version when updating this
-ruby '2.6.2'
+ruby File.read('.ruby-version').strip
 
 gem 'rails', '~> 5.2.2.x'
 


### PR DESCRIPTION
## Overview

Reduced maintenance burden for the team by picking up the Ruby version
from the `.ruby-version` file. 🎉 This change ensures the
`.ruby-version` file defines the canonical Ruby version for the project
as it *should* be the source of truth for the entire project.

Upgrading Ruby, in the future, will be easier by having one less file
to maintain. 😉

## Notes

:wave: @CZagrobelny! I'm just poking around the project, so hope this helps.