### PR TITLE
Cohort tweaks and remove flags

### DIFF
--- a/app/controllers/accompaniment_leader/friends/activities_controller.rb
+++ b/app/controllers/accompaniment_leader/friends/activities_controller.rb
@@ -24,7 +24,6 @@ class AccompanimentLeader::Friends::ActivitiesController < AccompanimentLeaderCo
       :judge_id,
       :occur_at,
       :notes,
-      :public_notes
     ).merge(region_id: current_region.id)
   end
 

--- a/app/controllers/admin/activities_controller.rb
+++ b/app/controllers/admin/activities_controller.rb
@@ -25,7 +25,7 @@ class Admin::ActivitiesController < AdminController
     @activity = current_region.activities.new(activity_params)
     if activity.save
       flash[:success] = 'Activity/Accompaniment saved.'
-      redirect_to community_admin_activities_path(current_community.slug)
+      redirect_to community_admin_activities_path(current_community.slug, start_date: start_date)
     else
       flash.now[:error] = 'Activity/Accompaniment not saved.'
       render :new
@@ -36,9 +36,9 @@ class Admin::ActivitiesController < AdminController
     if activity.update(activity_params)
       flash[:success] = 'Activity/Accompaniment saved.'
       if activity.accompaniment_eligible?
-        redirect_to accompaniments_community_admin_activities_path(current_community.slug)
+        redirect_to accompaniments_community_admin_activities_path(current_community.slug, start_date: start_date)
       else
-        redirect_to community_admin_activities_path(current_community.slug)
+        redirect_to community_admin_activities_path(current_community.slug, start_date: start_date)
       end
     else
       flash.now[:error] = 'Activity/Accompaniment not saved.'
@@ -52,7 +52,7 @@ class Admin::ActivitiesController < AdminController
     else
       flash.now[:error] = 'There was an issue confirming this accompaniment.'
     end
-    redirect_to accompaniments_community_admin_activities_path
+    redirect_to accompaniments_community_admin_activities_path(start_date: start_date)
   end
 
   def unconfirm
@@ -61,13 +61,21 @@ class Admin::ActivitiesController < AdminController
     else
       flash.now[:error] = 'There was an issue unconfirming this accompaniment.'
     end
-    redirect_to accompaniments_community_admin_activities_path
+    redirect_to accompaniments_community_admin_activities_path(start_date: start_date)
   end
 
   private
 
   def activity
     @activity ||= current_region.activities.find(params[:id])
+  end
+
+  def start_date
+    @start_date ||= if activity.accompaniment_eligible?
+      activity.occur_at.beginning_of_week.to_date
+    else
+      activity.occur_at.beginning_of_month.to_date
+    end
   end
 
   def activity_params

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -74,7 +74,6 @@ class Admin::FriendsController < AdminController
       :date_of_birth,
       :status,
       :date_of_entry,
-      :border_queue_number,
       :notes,
       :asylum_status,
       :asylum_notes,

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -5,7 +5,6 @@ class Admin::FriendsController < AdminController
                                           default_filter_params: { sorted_by: 'created_at_desc' },
                                           select_options: {
                                             sorted_by: Friend.options_for_sorted_by,
-                                            filter_border_crossing_status: Friend::BORDER_CROSSING_STATUSES,
                                           },
                                           persistence_id: false)
 
@@ -75,7 +74,6 @@ class Admin::FriendsController < AdminController
       :date_of_birth,
       :status,
       :date_of_entry,
-      :border_crossing_status,
       :border_queue_number,
       :notes,
       :asylum_status,

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -1,17 +1,12 @@
 class Admin::FriendsController < AdminController
   def index
-    filter_clinic_wait_list_priorities = params.dig('filterrific', 'filter_clinic_wait_list_priority')
-    if filter_clinic_wait_list_priorities.present?
-      params['filterrific']['filter_clinic_wait_list_priority'] = filter_clinic_wait_list_priorities.reject!(&:empty?)
-    end
-
     @filterrific = initialize_filterrific(Friend,
                                           params[:filterrific],
                                           default_filter_params: { sorted_by: 'created_at_desc' },
                                           select_options: {
                                             sorted_by: Friend.options_for_sorted_by,
                                             filter_border_crossing_status: Friend::BORDER_CROSSING_STATUSES,
-                                            filter_clinic_wait_list_priority: Friend.clinic_wait_list_priorities.map { |key, value| [key.humanize, key] }},
+                                          },
                                           persistence_id: false)
 
     @friends = current_community.friends.filterrific_find(@filterrific).paginate(page: params[:page])
@@ -118,7 +113,6 @@ class Admin::FriendsController < AdminController
       :intake_notes,
       :must_be_seen_by,
       :intake_date,
-      :clinic_wait_list_priority,
       language_ids: [],
       user_ids: []
     ).merge(community_id: current_community.id, region_id: current_region.id)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -64,14 +64,6 @@ class Activity < ApplicationRecord
     occur_at
   end
 
-  User.roles.each do |role, _index|
-    define_method "#{role}_accompaniments" do
-      accompaniments.select do |accompaniment|
-        accompaniment.user.role == role
-      end
-    end
-  end
-
   def accompaniment_leader_accompaniments
     accompaniments.select do |accompaniment|
       accompaniment.user.role == 'accompaniment_leader'

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -98,10 +98,6 @@ class Friend < ApplicationRecord
     where(a_number: number)
   }
 
-  scope :filter_border_queue_number, ->(number) {
-    where(border_queue_number: number)
-  }
-
   scope :filter_detained, ->(detained) {
     where(status: 'in_detention') if detained == 1
   }
@@ -163,8 +159,6 @@ class Friend < ApplicationRecord
     when /^created_at_/
       # Simple sort on the created_at column.
       order("friends.created_at #{direction}")
-    when /^border_queue_number/
-      where('border_queue_number IS NOT NULL').order("friends.border_queue_number #{direction}")
     when /^intake_date_/
       where('intake_date IS NOT NULL').order("friends.intake_date #{direction}")
     when /^must_be_seen_by_/
@@ -186,7 +180,6 @@ class Friend < ApplicationRecord
                                     filter_asylum_application_deadline_ending_before
                                     filter_created_after
                                     filter_created_before
-                                    filter_border_queue_number
                                     filter_application_status
                                     filter_phone_number
                                     filter_notes
@@ -197,8 +190,6 @@ class Friend < ApplicationRecord
     [
       %w[Newest created_at_desc],
       %w[Oldest created_at_asc],
-      ['Border Queue Number (Low to High)', 'border_queue_number_asc'],
-      ['Border Queue Number (High to Low)', 'border_queue_number_desc'],
       ['Intake Date (Ascending)', 'intake_date_asc'],
       ['Intake Date (Descending)', 'intake_date_desc'],
       ['Must Be Seen By (Soonest)', 'must_be_seen_by_asc'],

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -40,8 +40,6 @@ class Friend < ApplicationRecord
                           appeal pending
                           motion_to_reopen_submitted].map { |status| [status.titlecase, status] }
 
-  BORDER_CROSSING_STATUSES = %w[ready_to_cross detained_while_crossing successfully_crossed].map { |status| [status.titlecase, status] }
-
   ASYLUM_APPLICATION_DEADLINE = 1.year
 
   belongs_to :community
@@ -126,10 +124,6 @@ class Friend < ApplicationRecord
     where('created_at <= ?', string_to_end_of_date(date))
   }
 
-  scope :filter_border_crossing_status, ->(status) {
-    where(border_crossing_status: status)
-  }
-
   scope :filter_application_status, ->(status) {
     status = %i[in_review changes_requested approved] if status == 'all_active'
     joins(:applications)
@@ -193,7 +187,6 @@ class Friend < ApplicationRecord
                                     filter_created_after
                                     filter_created_before
                                     filter_border_queue_number
-                                    filter_border_crossing_status
                                     filter_application_status
                                     filter_phone_number
                                     filter_notes

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -37,8 +37,8 @@ class Friend < ApplicationRecord
 
   EOIR_CASE_STATUSES = %w[case_pending
                           immigration_judge_ordered_removal
-                          prior_voluntary_departure 
-                          appeal pending 
+                          prior_voluntary_departure
+                          appeal pending
                           motion_to_reopen_submitted].map { |status| [status.titlecase, status] }
 
   BORDER_CROSSING_STATUSES = %w[ready_to_cross detained_while_crossing successfully_crossed].map { |status| [status.titlecase, status] }
@@ -143,12 +143,12 @@ class Friend < ApplicationRecord
   }
 
   scope :filter_phone_number, ->(phone) {
-    return nil if phone.blank? 
+    return nil if phone.blank?
 
     # cast to string (if query just "123", would get integer)
     # lowercase & normalize . () - + and space out
     number_chunks = phone.to_s.downcase.split(/[\s+\-\(\)\.\+]/)
-    
+
     # make this a wildcard search by surrounding with %
     number_chunks = number_chunks.map { |chunk|
       "%" + chunk + "%"
@@ -163,7 +163,7 @@ class Friend < ApplicationRecord
     )
   }
 
-  pg_search_scope :filter_notes, against: :notes, using: { 
+  pg_search_scope :filter_notes, against: :notes, using: {
     tsearch: { dictionary: "english" }
   }
 
@@ -238,8 +238,8 @@ class Friend < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
-  def name_and_clinic_priority
-    "#{name} (#{clinic_wait_list_priority.titlecase})"
+  def name_and_id
+    "#{name} (#{id})"
   end
 
   def ethnicity

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -3,7 +3,6 @@ class Friend < ApplicationRecord
 
   enum ethnicity: %i[white black hispanic asian south_asian caribbean indigenous other]
   enum gender: %i[male female awesome]
-  enum clinic_wait_list_priority: %i[priority needs_attention can_wait]
 
   STATUSES = %w[in_deportation_proceedings
                 not_in_deportation_proceedings
@@ -127,10 +126,6 @@ class Friend < ApplicationRecord
     where('created_at <= ?', string_to_end_of_date(date))
   }
 
-  scope :filter_clinic_wait_list_priority, lambda { |priorities|
-    where(clinic_wait_list_priority: [*priorities])
-  }
-
   scope :filter_border_crossing_status, ->(status) {
     where(border_crossing_status: status)
   }
@@ -182,8 +177,6 @@ class Friend < ApplicationRecord
       where('must_be_seen_by IS NOT NULL').order("friends.must_be_seen_by #{direction}")
     when /^date_of_entry/
       where('date_of_entry IS NOT NULL').order("friends.date_of_entry #{direction}")
-    when /^clinic_wait_list_priority_/
-      where('clinic_wait_list_priority IS NOT NULL').order("friends.clinic_wait_list_priority #{direction}")
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end
@@ -199,7 +192,6 @@ class Friend < ApplicationRecord
                                     filter_asylum_application_deadline_ending_before
                                     filter_created_after
                                     filter_created_before
-                                    filter_clinic_wait_list_priority
                                     filter_border_queue_number
                                     filter_border_crossing_status
                                     filter_application_status
@@ -219,8 +211,6 @@ class Friend < ApplicationRecord
       ['Must Be Seen By (Soonest)', 'must_be_seen_by_asc'],
       ['Date of Entry (Ascending)', 'date_of_entry_asc'],
       ['Date of Entry (Descending)', 'date_of_entry_desc'],
-      ['Clinic Wait List Priority (Highest)', 'clinic_wait_list_priority_asc'],
-      ['Clinic Wait List Priority (Lowest)', 'clinic_wait_list_priority_desc']
     ]
   end
 
@@ -266,17 +256,6 @@ class Friend < ApplicationRecord
 
   def self.string_to_end_of_date(date)
     date.to_str.to_date.end_of_day
-  end
-
-  def clinic_wait_list_class
-    case self.clinic_wait_list_priority
-    when "priority"
-      return "clinic_waitlist_pri_high"
-    when "needs_attention"
-      return "clinic_waitlist_pri_med"
-    when "can_wait"
-      return "clinic_waitlist_pri_low"
-    end
   end
 
   private

--- a/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
+++ b/app/views/accompaniment_leader/activities/_accompaniment_modal.html.erb
@@ -73,6 +73,11 @@
               </div>
             <% end %>
             <% if current_user.attending?(activity) %>
+              <hr></hr>
+              <p>
+                <strong>Volunteer Emails:  </strong>
+                <%= activity.volunteer_accompaniments.map{ |accompaniment| accompaniment.user.email }.join(', ') %>
+              </p>
               <% if current_user.accompaniment_report_for(activity).present? %>
                 <%= link_to 'Edit Report Back', edit_community_accompaniment_leader_activity_accompaniment_report_path(current_community.slug, activity, current_user.accompaniment_report_for(activity)), class: 'btn btn-info' %>
               <% else %>

--- a/app/views/accompaniment_leader/friends/activities/_form.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/_form.html.erb
@@ -48,13 +48,6 @@
       </div>
     </div>
 
-    <div class='row form-group'>
-      <%= f.label :public_notes, class: 'col-md-3 col-xs-12 control-label' %>
-      <div class='col-md-6 col-xs-12'>
-        <%= f.text_area :public_notes, {class: 'form-control', style: 'height: 200px;'} %>
-      </div>
-    </div>
-
     <div class='row'>
       <div class='col-md-1 col-md-offset-10'>
         <%= f.submit 'Save', class: 'btn btn-primary' %>

--- a/app/views/admin/cohorts/_friend_assignment.html.erb
+++ b/app/views/admin/cohorts/_friend_assignment.html.erb
@@ -1,6 +1,6 @@
 <h3>Friends Assigned</h3>
 <%= form_for [current_community, :admin, cohort, FriendCohortAssignment.new], remote: true do |f| %>
-  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends.where('clinic_wait_list_priority IS NOT NULL'), 'id', 'name_and_clinic_priority', disabled: FriendCohortAssignment.all.pluck(:friend_id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
+  <%= f.select(:friend_id, options_from_collection_for_select(current_community.friends, 'id', 'name_and_id', disabled: FriendCohortAssignment.all.pluck(:friend_id)), {}, {multiple: true, prompt: true, class: 'chzn-select form-control'}) %>
 <% end %>
 <br>
 <table class='table table-bordered'>
@@ -8,6 +8,7 @@
     <tr>
       <th />
       <th>Name</th>
+      <th>Birthdate (M/D)</th>
       <th>Confirmed</th>
       <% @events.each do |event| %>
         <th><%= event.date.strftime("%-m/%-d") %></th>
@@ -30,6 +31,9 @@
             ), target: '_blank', id: "edit-user-#{assignment.friend.id}" do %>
             <% "#{assignment.friend.name}" %>
           <% end %>
+        </td>
+        <td>
+          <%= assignment.friend.date_of_birth.try(:strftime, '%m/%d') %>
         </td>
         <td>
           <%= form_for [current_community, :admin, cohort, assignment]  do |f| %>

--- a/app/views/admin/friends/_basic_form_fields.html.erb
+++ b/app/views/admin/friends/_basic_form_fields.html.erb
@@ -141,13 +141,6 @@
 </div>
 
 <div class='row form-group'>
-  <%= f.label :border_crossing_status, 'Border Crossing Status', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.select :border_crossing_status, options_for_select(Friend::BORDER_CROSSING_STATUSES, @friend.border_crossing_status), {include_blank: true}, {class: 'form-control'} %>
-  </div>
-</div>
-
-<div class='row form-group'>
   <%= f.label :notes, class: 'col-md-2 control-label' %>
   <div class='col-md-10'>
     <%= f.text_area :notes, class: 'form-control', style: 'height: 200px;' %>

--- a/app/views/admin/friends/_basic_form_fields.html.erb
+++ b/app/views/admin/friends/_basic_form_fields.html.erb
@@ -134,13 +134,6 @@
 </div>
 
 <div class='row form-group'>
-  <%= f.label :border_queue_number, 'Border Queue Number', class: 'col-md-2 control-label' %>
-  <div class='col-md-6'>
-    <%= f.text_field :border_queue_number, class: 'form-control' %>
-  </div>
-</div>
-
-<div class='row form-group'>
   <%= f.label :notes, class: 'col-md-2 control-label' %>
   <div class='col-md-10'>
     <%= f.text_area :notes, class: 'form-control', style: 'height: 200px;' %>

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -1,13 +1,5 @@
 <div class='form_fields_section'>
   <h3>Intake</h3>
-  <div class='row form-group'>
-    <%= f.label :clinic_wait_list_priority, 'Clinic Wait List Priority', class: 'col-md-2 control-label' %>
-    <div class='col-md-6'>
-      <%= f.select :clinic_wait_list_priority,
-      options_for_select(Friend.clinic_wait_list_priorities.map { |key, value| [key.humanize, key] }, @friend.clinic_wait_list_priority),
-      {include_blank: true}, {class: 'form-control'} %>
-    </div>
-  </div>
 
   <div class='row form-group'>
     <%= f.label :intake_date, 'Intake Date', class: 'col-md-2 control-label' %>

--- a/app/views/admin/friends/_search_friends.html.erb
+++ b/app/views/admin/friends/_search_friends.html.erb
@@ -51,17 +51,6 @@
       <%= f.text_field :filter_created_before, class: 'datepicker form-control' %>
     </div>
   </div>
-
-  <div class='row'>
-    <div class='form-group inline-form-group'>
-      <div class='col-md-2'>
-        <%= f.label :filter_clinic_wait_list_priority, 'Wait List Priority(s):' %>
-      </div>
-      <div class='col-md-5'>
-        <%= f.select :filter_clinic_wait_list_priority, @filterrific.select_options[:filter_clinic_wait_list_priority], { include_blank: true }, multiple: true, class: 'chzn-select form-control-lg' %>
-      </div>
-    </div>
-  </div>
   <br>
 
   <div class='row'>

--- a/app/views/admin/friends/_search_friends.html.erb
+++ b/app/views/admin/friends/_search_friends.html.erb
@@ -51,14 +51,6 @@
       <%= f.text_field :filter_created_before, class: 'datepicker form-control' %>
     </div>
   </div>
-  <br>
-
-  <div class='row'>
-    <div class='form-group col-md-5 inline-form-group'>
-      <%= f.label :filter_border_queue_number, 'Border Queue Number' %>
-      <%= f.text_field(:filter_border_queue_number, class: 'form-control') %>
-    </div>
-  </div>
 
   <div class='row'>
     <div class='form-group col-md-12 inline-form-group'>

--- a/app/views/admin/friends/_search_friends.html.erb
+++ b/app/views/admin/friends/_search_friends.html.erb
@@ -58,11 +58,6 @@
       <%= f.label :filter_border_queue_number, 'Border Queue Number' %>
       <%= f.text_field(:filter_border_queue_number, class: 'form-control') %>
     </div>
-
-    <div class='form-group col-md-5 inline-form-group'>
-      <%= f.label :filter_border_crossing_status, 'Border Crossing Status' %>
-      <%= f.select :filter_border_crossing_status, @filterrific.select_options[:filter_border_crossing_status], { include_blank: true }, class: 'form-control' %>
-    </div>
   </div>
 
   <div class='row'>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -31,11 +31,6 @@
             <% if friend.cohorts.present? %>
               <i class='far fa-calendar-check' style="color: <%= friend.cohorts.first.color %>;"></i>
             <% end %>
-            <% if friend.clinic_wait_list_priority %>
-              <span class="friend_id_clinic_waitlist <%= friend.clinic_wait_list_class %>">
-                <i class='fas fa-flag' style='font-size:14px;'></i>
-              </span>
-            <% end %>
           </td>
           <td><%= link_to friend.first_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
           <td><%= link_to friend.last_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -12,12 +12,9 @@
         <th>ID</th>
         <th>First Name</th>
         <th>Last Name</th>
-        <% if current_region.border? %>
-          <th>Border Queue Number</th>
-        <% else %>
-          <th>A#</th>
-        <% end %>
+        <th>A#</th>
         <th>Phone Number</th>
+        <th>Date of Entry</th>
         <th>Created</th>
         <th>Actions</th>
       </tr>
@@ -36,6 +33,7 @@
           <td><%= link_to friend.last_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
           <td><%= friend.a_number %></td>
           <td><%= friend.phone %></td>
+          <td><%= friend.date_of_entry.try(:strftime, '%m/%d/%y') %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
           <td>
             <div class='btn-group'>

--- a/app/views/admin/friends/index.html.erb
+++ b/app/views/admin/friends/index.html.erb
@@ -34,11 +34,7 @@
           </td>
           <td><%= link_to friend.first_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
           <td><%= link_to friend.last_name, edit_community_admin_friend_path(current_community.slug, friend) %></td>
-          <% if current_region.border? %>
-            <td><%= friend.border_queue_number %></td>
-          <% else %>
-            <td><%= friend.a_number %></td>
-          <% end %>
+          <td><%= friend.a_number %></td>
           <td><%= friend.phone %></td>
           <td><%= friend.created_at.strftime('%m/%d/%y') %></td>
           <td>

--- a/app/views/friends/_info.html.erb
+++ b/app/views/friends/_info.html.erb
@@ -18,7 +18,6 @@
 <p><strong>Status:  </strong><%= friend.status.try(:humanize) %></p>
 <p><strong>Date of Entry:  </strong><%= friend.date_of_entry.strftime('%m/%d/%y') if friend.date_of_entry.present? %></p>
 <p><strong>Border Queue Number:  </strong><%= friend.border_queue_number %></p>
-<p><strong>Border Crossing Status:  </strong><%= friend.border_crossing_status.try(:titlecase) %></p>
 <p><strong>Notes:  </strong><%= friend.notes %></p>
 
 <h3>Family</h3>

--- a/app/views/friends/_info.html.erb
+++ b/app/views/friends/_info.html.erb
@@ -17,7 +17,6 @@
 <p><strong>Date of Birth:  </strong><%= friend.date_of_birth.strftime('%m/%d/%y') if friend.date_of_birth.present? %></p>
 <p><strong>Status:  </strong><%= friend.status.try(:humanize) %></p>
 <p><strong>Date of Entry:  </strong><%= friend.date_of_entry.strftime('%m/%d/%y') if friend.date_of_entry.present? %></p>
-<p><strong>Border Queue Number:  </strong><%= friend.border_queue_number %></p>
 <p><strong>Notes:  </strong><%= friend.notes %></p>
 
 <h3>Family</h3>

--- a/db/migrate/20191001230832_remove_clinic_wait_list_priority_from_friends.rb
+++ b/db/migrate/20191001230832_remove_clinic_wait_list_priority_from_friends.rb
@@ -1,0 +1,5 @@
+class RemoveClinicWaitListPriorityFromFriends < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :friends, :clinic_wait_list_priority
+  end
+end

--- a/db/migrate/20191001232100_remove_border_crossing_status_from_friends.rb
+++ b/db/migrate/20191001232100_remove_border_crossing_status_from_friends.rb
@@ -1,0 +1,5 @@
+class RemoveBorderCrossingStatusFromFriends < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :friends, :border_crossing_status
+  end
+end

--- a/db/migrate/20191001232925_remove_border_queue_number_from_friends.rb
+++ b/db/migrate/20191001232925_remove_border_queue_number_from_friends.rb
@@ -1,0 +1,5 @@
+class RemoveBorderQueueNumberFromFriends < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :friends, :border_queue_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_230832) do
+ActiveRecord::Schema.define(version: 2019_10_01_232100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,7 +218,6 @@ ActiveRecord::Schema.define(version: 2019_10_01_230832) do
     t.string "sponsor_name"
     t.string "sponsor_phone_number"
     t.string "sponsor_relationship"
-    t.string "border_crossing_status"
     t.integer "border_queue_number"
     t.string "city"
     t.string "jail_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_223234) do
+ActiveRecord::Schema.define(version: 2019_10_01_230832) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -225,7 +225,6 @@ ActiveRecord::Schema.define(version: 2019_09_05_223234) do
     t.text "intake_notes"
     t.datetime "intake_date"
     t.datetime "must_be_seen_by"
-    t.integer "clinic_wait_list_priority"
     t.string "eoir_case_status"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_01_232100) do
+ActiveRecord::Schema.define(version: 2019_10_01_232925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -218,7 +218,6 @@ ActiveRecord::Schema.define(version: 2019_10_01_232100) do
     t.string "sponsor_name"
     t.string "sponsor_phone_number"
     t.string "sponsor_relationship"
-    t.integer "border_queue_number"
     t.string "city"
     t.string "jail_id"
     t.text "intake_notes"


### PR DESCRIPTION
## Why is this PR needed?

Bunch of small changes NSC requested.

- Cohort Functionality: add date/month of birth to the Cohort table.  Also, remove the priority assignment scope from cohort Friend list
- Remove all flags (and disable flags functionality)
- Remove border queue number and border crossing status
- Add non-accompaniment eligible activities for ‘Biometric Appointment’, ’Asylum Interview’, ‘Filing Motion to Reopen’, ‘Filing Appeal’
- Accompaniment leaders do not need to be able to add ‘public notes’ for an activity, that field has been removed for accompaniment leaders
- Date of entry added to the table on Friends index
- When I edit or confirm an activity, I want to be taken back to the week for that activity (not the current week)
- Accompaniment leaders (who are attending an accompaniment) see a list of volunteer emails at the bottom of the modal for the accompaniment.  This is different than what we discussed, ie. having a button that would open a blank email with all of the volunteer emails as recipients.  Turns out that there is not a reliable way to specify multiple email addresses to mail to…and I didn’t want the functionality to be unreliable.  But I figured this solution would allow them to copy/paste once (rather than many times).  I am attaching a screenshot to show you what the accompaniment leaders would see.

## Deploy

rake db:migrate
