### PR TITLE
copy the directory before running bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ COPY Gemfile.lock /sanctuary/
 WORKDIR /sanctuary
 
 # Bundle install
-RUN gem install bundler && bundle install
 COPY . /sanctuary
+RUN gem install bundler && bundle install
 RUN rm -rf /sanctuary/tmp/pids/server.pid
 
 EXPOSE 5000


### PR DESCRIPTION
## Why is this PR needed?

When you pull down a fresh copy of the repo you run into an error trying to run `make build` because it cannot find `.ruby-version` . This is a confusing dev experience and could slow people down trying to setup the repo locally

## Solution
There is probably a more elegant docker solution, but this quick fix is to move up the step when we copy over the current directory so the docker container has access to the `.ruby-version` file. Another solution could be to explicitly copy that one file further up.

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/282