### PR TITLE
An admin can 'hide' Judges from the list

### DIFF
--- a/app/controllers/admin/judges_controller.rb
+++ b/app/controllers/admin/judges_controller.rb
@@ -1,6 +1,6 @@
 class Admin::JudgesController < AdminController
   before_action :require_primary_community
-  before_action :set_judge, only: %i[edit update]
+  before_action :set_judge, only: %i[edit update hide]
 
   def index
     @judges = current_region.judges.order('last_name asc').paginate(page: params[:page])
@@ -32,6 +32,15 @@ class Admin::JudgesController < AdminController
     end
   end
 
+  def hide
+    if @judge.update(hidden: true)
+      redirect_to community_admin_judges_path(current_community.slug)
+    else
+      flash.now[:error] = 'Something went wrong :('
+      render 'edit'
+    end
+  end
+
   private
 
   def set_judge
@@ -39,6 +48,6 @@ class Admin::JudgesController < AdminController
   end
 
   def judge_params
-    params.require(:judge).permit(:first_name, :last_name)
+    params.require(:judge).permit(:first_name, :last_name, :hidden)
   end
 end

--- a/app/controllers/admin/judges_controller.rb
+++ b/app/controllers/admin/judges_controller.rb
@@ -1,6 +1,6 @@
 class Admin::JudgesController < AdminController
   before_action :require_primary_community
-  before_action :set_judge, only: %i[edit update hide]
+  before_action :set_judge, only: %i[edit update toggle]
 
   def index
     @judges = current_region.judges.order('last_name asc').paginate(page: params[:page])
@@ -32,8 +32,8 @@ class Admin::JudgesController < AdminController
     end
   end
 
-  def hide
-    if @judge.update(hidden: true)
+  def toggle
+    if @judge.update(hidden: !@judge.hidden)
       redirect_to community_admin_judges_path(current_community.slug)
     else
       flash.now[:error] = 'Something went wrong :('

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -3,10 +3,16 @@ class Judge < ApplicationRecord
   belongs_to :region
   has_many :activities
 
-  default_scope { active }
-
   scope :active, -> { where(hidden: false) }
   scope :hidden, -> { where(hidden: true) }
+
+  def active?
+    hidden == false
+  end
+
+  def hidden?
+    hidden == true
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -3,6 +3,11 @@ class Judge < ApplicationRecord
   belongs_to :region
   has_many :activities
 
+  default_scope { active }
+
+  scope :active, -> { where(hidden: false) }
+  scope :hidden, -> { where(hidden: true) }
+
   def name
     "#{first_name} #{last_name}"
   end

--- a/app/views/accompaniment_leader/friends/activities/_form.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/_form.html.erb
@@ -28,7 +28,7 @@
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges.active, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 

--- a/app/views/admin/activities/_form.html.erb
+++ b/app/views/admin/activities/_form.html.erb
@@ -28,7 +28,7 @@
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges.active, :id, :name, {prompt: true}, {class: 'chzn-select form-control'}) %>
       </div>
     </div>
 

--- a/app/views/admin/friends/activities/_form.html.erb
+++ b/app/views/admin/friends/activities/_form.html.erb
@@ -21,7 +21,7 @@
     <div class='row form-group'>
       <%= f.label :judge_id, 'Judge', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
-        <%= collection_select(:activity, :judge_id, current_region.judges, :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
+        <%= collection_select(:activity, :judge_id, current_region.judges.active, :id, :name, {prompt: true}, {class: 'form-control chzn-select'}) %>
       </div>
     </div>
 

--- a/app/views/admin/judges/_form.html.erb
+++ b/app/views/admin/judges/_form.html.erb
@@ -16,6 +16,13 @@
         <%= f.text_field :last_name, class: 'form-control' %>
       </div>
     </div>
+
+    <div class='row form-group'>
+      <%= f.label :hidden, 'Hidden', class: 'col-md-2 control-label required' %>
+      <div class='col-md-6'>
+        <%= f.check_box :hidden %>
+      </div>
+    </div>
   </div>
 
   <div class='row'>

--- a/app/views/admin/judges/index.html.erb
+++ b/app/views/admin/judges/index.html.erb
@@ -18,11 +18,15 @@
         <tbody>
           <% @judges.each do |judge| %>
             <tr>
-              <td><%= link_to "#{judge.last_name}, #{judge.first_name}", edit_community_admin_judge_path(current_community.slug, judge) %></td>
+              <td><%= link_to "#{judge.last_name}, #{judge.first_name}", edit_community_admin_judge_path(current_community.slug, judge), class: judge.hidden? ? 'text-muted' : '' %></td>
               <td>
                 <div class='btn-group'>
-                  <%= link_to(hide_community_admin_judge_path(current_community.slug, judge), method: :patch, id: "hide-judge-#{judge.id}", class: 'btn btn-default') do %>
-                    <i class="fa fa-eye-slash"></i> Hide
+                  <%= link_to(toggle_community_admin_judge_path(current_community.slug, judge), method: :patch, class: 'btn btn-default') do %>
+                    <% if judge.active? %>
+                      <i class="fa fa-eye-slash"></i> Hide
+                    <% else %>
+                      <i class="fa fa-eye"></i> Show
+                    <% end %>
                   <% end %>
                 </div>
               </td>

--- a/app/views/admin/judges/index.html.erb
+++ b/app/views/admin/judges/index.html.erb
@@ -12,12 +12,20 @@
         <thead>
           <tr>
             <th>Name</th>
+            <th>Actions</th>
             </tr>
         </thead>
         <tbody>
           <% @judges.each do |judge| %>
             <tr>
               <td><%= link_to "#{judge.last_name}, #{judge.first_name}", edit_community_admin_judge_path(current_community.slug, judge) %></td>
+              <td>
+                <div class='btn-group'>
+                  <%= link_to(hide_community_admin_judge_path(current_community.slug, judge), method: :patch, id: "hide-judge-#{judge.id}", class: 'btn btn-default') do %>
+                    <i class="fa fa-eye-slash"></i> Hide
+                  <% end %>
+                </div>
+              </td>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,7 +59,11 @@ Rails.application.routes.draw do
         resources :family_relationships, only: [:new, :create, :destroy]
       end
 
-      resources :judges, except: [:show, :destroy]
+      resources :judges, except: [:show, :destroy] do
+        member do
+          patch :hide
+        end
+      end
       resources :locations, except: [:show, :destroy]
       resources :sanctuaries, except: [:show, :destroy]
       resources :lawyers, except: [:show, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
 
       resources :judges, except: [:show, :destroy] do
         member do
-          patch :hide
+          patch :toggle
         end
       end
       resources :locations, except: [:show, :destroy]

--- a/db/migrate/20191113210459_judges_add_hidden.rb
+++ b/db/migrate/20191113210459_judges_add_hidden.rb
@@ -1,0 +1,5 @@
+class JudgesAddHidden < ActiveRecord::Migration[5.2]
+  def change
+    add_column :judges, :hidden, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_143158) do
+ActiveRecord::Schema.define(version: 2019_11_13_210459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2019_11_06_143158) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "region_id"
+    t.boolean "hidden", default: false
     t.index ["region_id"], name: "index_judges_on_region_id"
   end
 

--- a/spec/factories/activity_factory.rb
+++ b/spec/factories/activity_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     association :friend
     association :location
     association :region
+    association :judge
     association :activity_type
     occur_at { 1.day.from_now }
   end

--- a/spec/factories/judge_factory.rb
+++ b/spec/factories/judge_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :judge do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+    hidden { false }
     association :region
   end
 end

--- a/spec/features/community_admin/create_a_new_judge_spec.rb
+++ b/spec/features/community_admin/create_a_new_judge_spec.rb
@@ -10,15 +10,20 @@ RSpec.describe 'Admin creates a new judge', type: :feature do
   end
 
   scenario 'creating a new judge' do
-    judge_count = region.judges.count
     visit new_community_admin_judge_path(community)
 
     fill_in 'First Name', with: Faker::Name.first_name
     fill_in 'Last Name', with: Faker::Name.last_name
-    click_button 'Save'
 
-    expect(region.judges.count).to eq (judge_count + 1)
+    expect { click_button 'Save' }.to change { region.judges.count }.from(0).to(1)
     expect(current_path).to eq community_admin_judges_path(community)
   end
 
+  scenario 'hiding a judge' do
+    create(:judge, region: region)
+
+    visit community_admin_judges_path(community)
+
+    expect { click_on 'Hide' }.to change { region.judges.count }.from(1).to(0)
+  end
 end

--- a/spec/features/community_admin/create_a_new_judge_spec.rb
+++ b/spec/features/community_admin/create_a_new_judge_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'Admin creates a new judge', type: :feature do
 
     visit community_admin_judges_path(community)
 
-    expect { click_on 'Hide' }.to change { region.judges.count }.from(1).to(0)
+    expect { click_on 'Hide' }.to change { region.judges.active.count }.from(1).to(0)
+    expect { click_on 'Show' }.to change { region.judges.active.count }.from(0).to(1)
   end
 end

--- a/spec/features/community_admin/friend_management_spec.rb
+++ b/spec/features/community_admin/friend_management_spec.rb
@@ -24,4 +24,14 @@ RSpec.describe 'Friend management', type: :feature do
       expect(current_path).to eq edit_community_admin_friend_path(community, friend)
     end
   end
+
+  scenario 'viewing activity for a friend shows hidden judge' do
+    judge = create(:judge, region: community.region, hidden: true)
+    create(:activity, judge: judge, friend: friend)
+
+    visit community_admin_friends_path(community)
+    click_link "edit-friend-#{friend.id}"
+    click_link 'Activities/Accompaniments'
+    expect(page).to have_content("Judge: #{judge.name}")
+  end
 end


### PR DESCRIPTION
## Why is this PR needed?

Addresses #280

## Solution

I followed the suggested implementation and wrote a browser test.

This PR creates two new scopes for judges. The `active` scope only returns active judges, and the `hidden` scope only returns hidden judges.

In addition, the story described needing to exclude hidden judges everywhere where they are listed, namely the admin judges index and judges drop-downs. This suggested to me that in all instances, the `active` scope was desirable, so I implemented that as the default scope for the judge model. Please note that this means there is no way to see a list of hidden judges in the admin panel -- that functionality will need to be added later when/if it's needed. (I imagine this could be added as a filter on the admin judges index.)

### Link to associated issue: 

Closes #280