### PR TITLE
Add line graph reflecting accompaniment attendance in primary communities (for admins only)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'textacular', '~> 5.0'
 gem 'timecop' #used for seed data on staging
 gem 'turbolinks', '~> 5.x'
 gem 'will_paginate', '~> 3.1'
+gem "chartkick"
 
 group :assets do
   gem 'coffee-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     carrierwave-aws (1.3.0)
       aws-sdk-s3 (~> 1.0)
       carrierwave (>= 0.7, < 2.0)
+    chartkick (3.3.0)
     chosen-rails (1.8.7)
       coffee-rails (>= 3.2)
       railties (>= 3.0)
@@ -392,6 +393,7 @@ DEPENDENCIES
   capybara-email
   carrierwave (~> 1.0)
   carrierwave-aws
+  chartkick
   chosen-rails
   coffee-rails
   database_cleaner (~> 1.5)
@@ -449,4 +451,4 @@ RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,9 +13,9 @@
 //= require jquery
 //= require jquery_ujs
 //= require jquery-ui/widgets/datepicker
+//= require chartkick
+//= require Chart.bundle
 //= require turbolinks
 //= require chosen-jquery
 //= require bootstrap
 //= require_tree .
-//= require chartkick
-//= require Chart.bundle

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,3 +17,5 @@
 //= require chosen-jquery
 //= require bootstrap
 //= require_tree .
+//= require chartkick
+//= require Chart.bundle

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -2,12 +2,36 @@ class Admin::StatsController < AdminController
 
   def index
     @activities_with_count = []
-    activities_by_week = Activity.confirmed.where(friend_id: current_community.friends).order('occur_at asc').group_by do |a|
+    confirmed_activities_by_week = Activity.confirmed.where(friend_id: current_community.friends).order('occur_at asc').group_by do |a|
       a.occur_at.strftime('%V')
     end
-    activities_count_by_week = activities_by_week.map{ |week, activities| [Date.commercial(2019,week.to_i), activities.count] }
+    activities_count_by_week = confirmed_activities_by_week.map{ |week, activities| [Date.commercial(2019,week.to_i), activities.count] }
     activities_count_by_week.each do |activity|
       @activities_with_count.push([activity[0],activity[1]])
+    end
+
+    @accompaniments_with_count = []
+
+    accompaniments = []
+    activities = Activity.where(friend_id: current_community.friends).order('occur_at asc')
+    activities.each do |a|
+      accompaniments.push(a.accompaniments)
+    end
+
+    parsed_accompaniments = []
+    accompaniments.each do |a|
+      a.each do |b|
+        parsed_accompaniments.push(b)
+      end
+    end
+
+    grouped_parsed_accompaniments = parsed_accompaniments.group_by do |a|
+      a.created_at.strftime('%V')
+    end
+
+    accompaniments_count_by_week = grouped_parsed_accompaniments.map{ |week, accompaniments| [Date.commercial(2019,week.to_i), accompaniments.count] }
+    accompaniments_count_by_week.each do |accompaniment|
+      @accompaniments_with_count.push([accompaniment[0],accompaniment[1]])
     end
   end
 end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -1,6 +1,13 @@
 class Admin::StatsController < AdminController
 
   def index
-
+    @activities_with_count = []
+    activities_by_week = Activity.confirmed.where(friend_id: current_community.friends).order('occur_at asc').group_by do |a|
+      a.occur_at.strftime('%V')
+    end
+    activities_count_by_week = activities_by_week.map{ |week, activities| [Date.commercial(2019,week.to_i), activities.count] }
+    activities_count_by_week.each do |activity|
+      @activities_with_count.push([activity[0],activity[1]])
+    end
   end
 end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -1,16 +1,13 @@
 class Admin::StatsController < AdminController
 
   def index
-    @activities_with_count = []
-    confirmed_activities_by_week = Activity.confirmed.where(friend_id: current_community.friends).order('occur_at asc').group_by do |a|
-      a.occur_at.strftime('%V')
-    end
+    activities_with_count = []
     activities_count_by_week = confirmed_activities_by_week.map{ |week, activities| [Date.commercial(2019,week.to_i), activities.count] }
     activities_count_by_week.each do |activity|
-      @activities_with_count.push([activity[0],activity[1]])
+      activities_with_count.push([activity[0],activity[1]])
     end
 
-    @accompaniments_with_count = []
+    accompaniments_with_count = []
     confirmed_activities_by_week.each do |activity|
       accompaniments = []
       activity[1].each do |a|
@@ -18,12 +15,20 @@ class Admin::StatsController < AdminController
           accompaniments.push(acc)
         end
       end
-      @accompaniments_with_count.push([Date.commercial(2019,activity[0].to_i),accompaniments.count])
+      accompaniments_with_count.push([Date.commercial(2019,activity[0].to_i),accompaniments.count])
     end
 
     @data = [
-      { name: 'Friends Accompanied', data: @activities_with_count},
-      { name: 'Volunteer Accompaniments', data: @accompaniments_with_count}
+      { name: 'Friends Accompanied', data: activities_with_count},
+      { name: 'Volunteer Accompaniments', data: accompaniments_with_count}
     ]
   end
+
+  private
+    def confirmed_activities_by_week
+      activities = Activity.confirmed.where(friend_id: current_community.friends).order('occur_at asc').group_by do |a|
+        a.occur_at.strftime('%V')
+      end
+      activities
+    end
 end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -1,0 +1,6 @@
+class Admin::StatsController < AdminController
+
+  def index
+
+  end
+end

--- a/app/controllers/admin/stats_controller.rb
+++ b/app/controllers/admin/stats_controller.rb
@@ -11,27 +11,19 @@ class Admin::StatsController < AdminController
     end
 
     @accompaniments_with_count = []
-
-    accompaniments = []
-    activities = Activity.where(friend_id: current_community.friends).order('occur_at asc')
-    activities.each do |a|
-      accompaniments.push(a.accompaniments)
-    end
-
-    parsed_accompaniments = []
-    accompaniments.each do |a|
-      a.each do |b|
-        parsed_accompaniments.push(b)
+    confirmed_activities_by_week.each do |activity|
+      accompaniments = []
+      activity[1].each do |a|
+        a.accompaniments.each do |acc|
+          accompaniments.push(acc)
+        end
       end
+      @accompaniments_with_count.push([Date.commercial(2019,activity[0].to_i),accompaniments.count])
     end
 
-    grouped_parsed_accompaniments = parsed_accompaniments.group_by do |a|
-      a.created_at.strftime('%V')
-    end
-
-    accompaniments_count_by_week = grouped_parsed_accompaniments.map{ |week, accompaniments| [Date.commercial(2019,week.to_i), accompaniments.count] }
-    accompaniments_count_by_week.each do |accompaniment|
-      @accompaniments_with_count.push([accompaniment[0],accompaniment[1]])
-    end
+    @data = [
+      { name: 'Friends Accompanied', data: @activities_with_count},
+      { name: 'Volunteer Accompaniments', data: @accompaniments_with_count}
+    ]
   end
 end

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -1,3 +1,6 @@
 <%= current_community.name %>
 
-<%= line_chart @activities_with_count, xtitle: "Date", ytitle: "Activites" %>
+<%= line_chart @activities_with_count, xtitle: "Date", ytitle: "Activites", title: "Friends Accompanied" %>
+
+<%= line_chart @accompaniments_with_count, xtitle: "Date", ytitle: "Accompaniments" %>
+

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -1,6 +1,7 @@
-<%= current_community.name %>
+<h1><%= current_community.name %></h1>
 
-<%= line_chart @activities_with_count, xtitle: "Date", ytitle: "Activites", title: "Friends Accompanied" %>
+<% mapped_data =  @data.map {|a|
+{name: a[:name], data: a[:data]}
+} %>
 
-<%= line_chart @accompaniments_with_count, xtitle: "Date", ytitle: "Accompaniments" %>
-
+<%= line_chart mapped_data, xtitle:"Date" %>

--- a/app/views/admin/stats/index.html.erb
+++ b/app/views/admin/stats/index.html.erb
@@ -1,0 +1,3 @@
+<%= current_community.name %>
+
+<%= line_chart @activities_with_count, xtitle: "Date", ytitle: "Activites" %>

--- a/app/views/shared/_primary_community_admin_navigation.html.erb
+++ b/app/views/shared/_primary_community_admin_navigation.html.erb
@@ -18,5 +18,6 @@
     <li><%= link_to 'Judges', community_admin_judges_path(current_community.slug) %></li>
     <li><%= link_to 'Locations', community_admin_locations_path(current_community.slug) %></li>
     <li><%= link_to 'Sanctuaries', community_admin_sanctuaries_path(current_community.slug) %></li>
+    <li><%= link_to 'Stats', community_admin_stats_path(current_community.slug) %></li>
   </ul>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,8 @@ Rails.application.routes.draw do
         end
         resources :friend_cohort_assignments, only: [:create, :update, :destroy]
       end
+
+      resources :stats
     end
 
     namespace :accompaniment_leader do


### PR DESCRIPTION
This pull request is a work in progress related to [issue 246](https://github.com/CZagrobelny/new_sanctuary_asylum/issues/246).

Future developers are welcome and encouraged to pick up this work.

TO DO:
- limit the returned activities to _past-year through current date_. **The current dates are hardcoded to reflect the weeks in 2019.**