### PR TITLE
WIP Adds Friend Notes

### DIFF
--- a/app/assets/javascripts/admin_friend_form.js
+++ b/app/assets/javascripts/admin_friend_form.js
@@ -44,6 +44,10 @@ $(document).on('turbolinks:load', function () {
   $('.open_ankle_monitor_modal').click(function() {
     $('#ankle_monitor_modal').modal('show');
   });
+
+  $('.open_friend_note_modal').click(function() {
+    $('#friend_note_modal').modal('show');
+  });
 });
 
 function activateChosen() {

--- a/app/controllers/admin/friends/friend_notes_controller.rb
+++ b/app/controllers/admin/friends/friend_notes_controller.rb
@@ -1,0 +1,50 @@
+class Admin::Friends::FriendNotesController < AdminController
+  def new
+    @friend_note = friend.friend_notes.new
+    render_modal
+  end
+  
+  def create
+    @friend_note = friend.friend_notes.build(friend_note_params)
+    if @friend_note.save
+      render_success
+    else
+      render_modal
+    end
+  end
+
+  def edit
+    render_modal
+  end
+
+  private
+
+  def friend_note
+    @friend_note ||= FriendNote.find(params[:id])
+  end
+
+  def friend
+    @friend ||= current_community.friends.find(params[:friend_id])
+  end
+
+  def detention_params
+    params.require(:detention).permit(
+      :friend_id,
+      :user_id,
+      :note
+    )
+  end
+
+  def render_modal
+    respond_to do |format|
+      format.js { render file: 'admin/friends/friend_notes/modal', locals: { friend: friend, friend_note: friend_note } }
+    end
+  end
+
+  def render_success
+    respond_to do |format|
+      format.js { render file: 'admin/friends/friend_notes/list', locals: { friend: friend } }
+    end
+  end
+
+end

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -60,6 +60,7 @@ class Friend < ApplicationRecord
   has_many :family_relationships, dependent: :destroy
   has_many :family_members, through: :family_relationships, source: 'relation'
   has_many :releases, dependent: :destroy
+  has_many :friend_notes
 
   accepts_nested_attributes_for :user_friend_associations, allow_destroy: true
 

--- a/app/models/friend_note.rb
+++ b/app/models/friend_note.rb
@@ -1,0 +1,4 @@
+class FriendNote < ApplicationRecord
+  belongs_to :friend
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
   has_many :releases
   has_many :reviews
   has_many :user_event_attendances, dependent: :destroy
+  has_many :friend_notes, dependent: :restrict_with_error
 
 
 

--- a/app/views/admin/friends/_basic_form_fields.html.erb
+++ b/app/views/admin/friends/_basic_form_fields.html.erb
@@ -139,3 +139,13 @@
     <%= f.text_area :notes, class: 'form-control', style: 'height: 200px;' %>
   </div>
 </div>
+
+<h3>Notes</h3>
+
+<div class='pull-right'>
+  <%= link_to 'Add Note', new_community_admin_friend_friend_note_path(current_community.slug, @friend), remote: true, class: 'btn btn-primary', data: { toggle: 'modal', target: '#friend_note_modal' } %>
+</div>
+
+<div id='friend-notes-list'>
+  <%= render partial: 'admin/friends/friend_notes/list', locals: { friend: @friend } %>
+</div>

--- a/app/views/admin/friends/friend_notes/_form.html.erb
+++ b/app/views/admin/friends/friend_notes/_form.html.erb
@@ -1,0 +1,26 @@
+<% if friend_note.errors.present? %>
+  <%= display_validation_errors(friend_note) %>
+<% end %>
+<%= form_for([current_community, :admin, friend, friend_note], controller: 'friends/friend_note', remote: true) do |f| %>
+  <div class='form-inputs'>
+
+    <div class='row form-group'>
+      <%= f.label :note, 'Note', class: 'col-md-12 control-label' %>
+      <div class='col-md-12'>
+        <%= f.text_area :note, {class: 'form-control', style: 'height: 200px;'} %>
+      </div>
+    </div>
+
+    <div class='row'>
+      <div class='col-md-1 col-md-offset-10'>
+        <%= f.submit 'Save', class: 'btn btn-primary' %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<script>
+  $(document).ready(function(){
+    activateChosen();
+  });
+</script>

--- a/app/views/admin/friends/friend_notes/_friend_note.html.erb
+++ b/app/views/admin/friends/friend_notes/_friend_note.html.erb
@@ -1,0 +1,11 @@
+<div class='row' style='margin-left:5px;'>
+  <strong>
+    <%# link_to 'Remove', community_admin_friend_detention_path(current_community.slug, friend, detention), method: :delete, remote: true, class: 'delete' %>
+  </strong><br>
+  "<%= friend_note.note if friend_note.note.present? %>"<br>
+  <strong>Last Edited By:  </strong><%=  friend_note.user.name if friend_note.user.present? %><br>
+  <strong>Updated At:  </strong><%=  friend_note.updated_at.strftime("%A, %B %-d, %Y") %><br>
+  <strong><% link_to "Edit", edit_community_admin_friend_friend_note_path(current_community.slug, friend, friend_note), remote: true, class: 'open_friend_note_modal' %></strong>
+</div>
+<br>
+<br>

--- a/app/views/admin/friends/friend_notes/_list.html.erb
+++ b/app/views/admin/friends/friend_notes/_list.html.erb
@@ -1,0 +1,13 @@
+<% if @friend.friend_notes.present? %>
+  <% @friend.friend_notes.order('updated_at desc').each do |friend_note| %>
+    <%= render partial: 'admin/friends/friend_notes/friend_note', locals: { friend: @friend, friend_note: friend_note } %>
+  <% end %>
+<% end %>
+
+<script>
+  $(document).ready(function () {
+    $('.open_friend_note_modal').click(function() {
+      $('#friend_note_modal').modal('show');
+    });
+  });
+</script>

--- a/app/views/admin/friends/friend_notes/_modal.html.erb
+++ b/app/views/admin/friends/friend_notes/_modal.html.erb
@@ -1,0 +1,15 @@
+<div class='modal' id='friend_note_modal'>
+  <div class='modal-dialog'>
+    <div class='modal-content'>
+      <div class='modal-header'>
+        <button type='button' class='close' data-dismiss='modal' aria-label='Close'><span aria-hidden='true'>&times;</span></button>
+        <h4 class='modal-title'>Friend Notes</h4>
+      </div>
+      <div class='modal-body'>
+        <div id='friend-note-form'>
+          <%= render partial: 'admin/friends/friend_notes/form', locals: { friend: friend_note.friend, frient_note: friend_note } %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/friends/friend_notes/list.js.erb
+++ b/app/views/admin/friends/friend_notes/list.js.erb
@@ -1,0 +1,2 @@
+$('#friend-note-list').html("<%= escape_javascript(render partial: 'admin/friends/friend_notes/list', locals: { friend_note: @friend_note } ) %>");
+$('#friend_note_modal').modal('hide');

--- a/app/views/admin/friends/friend_notes/modal.js.erb
+++ b/app/views/admin/friends/friend_notes/modal.js.erb
@@ -1,0 +1,1 @@
+$('#friend-note-form').html("<%= escape_javascript(render partial: 'admin/friends/friend_notes/form', locals: {friend_note: friend_note, friend: friend}) %>");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
           end
         end
         resources :detentions, controller: 'friends/detentions', except: [:index, :show]
+        resources :friend_notes, controller: 'friends/friend_notes', except: [:index, :show]
 
         resources :ankle_monitors, controller: 'friends/ankle_monitors', except: [:index, :show]
         resources :family_relationships, only: [:new, :create, :destroy]

--- a/db/migrate/20191115171634_add_friends_notes.rb
+++ b/db/migrate/20191115171634_add_friends_notes.rb
@@ -1,0 +1,10 @@
+class AddFriendsNotes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :friend_notes do |t|
+      t.references :friend, index:true, foreign_key: true
+      t.references :user, index:true, foreign_key: true
+      t.text :note
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_06_143158) do
+ActiveRecord::Schema.define(version: 2019_11_15_171634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,6 +178,16 @@ ActiveRecord::Schema.define(version: 2019_11_06_143158) do
     t.datetime "updated_at", null: false
     t.index ["friend_id"], name: "index_friend_languages_on_friend_id"
     t.index ["language_id"], name: "index_friend_languages_on_language_id"
+  end
+
+  create_table "friend_notes", force: :cascade do |t|
+    t.bigint "friend_id"
+    t.bigint "user_id"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["friend_id"], name: "index_friend_notes_on_friend_id"
+    t.index ["user_id"], name: "index_friend_notes_on_user_id"
   end
 
   create_table "friends", id: :serial, force: :cascade do |t|
@@ -434,6 +444,8 @@ ActiveRecord::Schema.define(version: 2019_11_06_143158) do
   add_foreign_key "activities", "regions"
   add_foreign_key "communities", "regions"
   add_foreign_key "events", "communities"
+  add_foreign_key "friend_notes", "friends"
+  add_foreign_key "friend_notes", "users"
   add_foreign_key "friends", "communities"
   add_foreign_key "friends", "regions"
   add_foreign_key "judges", "regions"


### PR DESCRIPTION
## Why is this PR needed?

The 'Notes' field on Friend has proven to be one of the most invaluable fields on the Friend record! It often includes information that shows the history of a Friend's case, and when admins add onto the notes (it's a single field at this point) they date and initial their additions. It would be EVEN better if this could be done automatically when individual notes are added.

## Status of work

This PR is still in progress, but I should be able to work on this over the weekend of 11/23 - 11/24.

Currently, though I'm mimicking the flow for Detention CRUD for Friend Notes, something is amiss with showing the modal and completing the create and update flow.

## Solution

- [x] create FriendNotes model and table
- [ ] create a CRUD flow similar to Detentions
- [ ] remove Friend Notes for volunteers
- [ ] tests

### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/273