### PR TITLE
Add bundle exec to rake db:setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       sh -c '
       ./wait-for-it.sh -t 30 db:5432;
       cp config/database_docker.yml.sample config/database.yml;
-      rake db:setup;
+      bunbdle exec rake db:setup;
       bundle exec rails s -p 5000 -b '0.0.0.0';
       '
     volumes:


### PR DESCRIPTION
Due to running rake db:setup without bundle exec, gets this error:
```
sanctuary_web | rake aborted!
sanctuary_web | Gem::LoadError: You have already activated rake 12.3.2, but your Gemfile requires rake 13.0.1. Prepending `bundle exec` to your command may solve this.
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/runtime.rb:312:in `check_for_activated_spec!'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/runtime.rb:31:in `block in setup'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/spec_set.rb:147:in `each'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/spec_set.rb:147:in `each'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/runtime.rb:26:in `map'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/runtime.rb:26:in `setup'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler.rb:149:in `setup'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/setup.rb:20:in `block in <top (required)>'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/ui/shell.rb:136:in `with_level'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/ui/shell.rb:88:in `silence'
sanctuary_web | /usr/local/bundle/gems/bundler-2.1.4/lib/bundler/setup.rb:20:in `<top (required)>'
sanctuary_web | /sanctuary/config/boot.rb:3:in `<top (required)>'
sanctuary_web | /sanctuary/config/application.rb:1:in `<top (required)>'
sanctuary_web | /sanctuary/rakefile:4:in `<top (required)>'
sanctuary_web | (See full trace by running task with --trace)
```

## Why is this PR needed?

_Describe if it is a problem or proposal and why it is valuable to the project._

## Solution

_Describe what led you to the solution and why you choose this approach._

_Remember to add pr-comments on the code for this that require more explanation to help reviewers._

### Link to associated issue: 
