### PR TITLE
Add "clinic plan" field to the Friend data model

### DIFF
--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -126,6 +126,7 @@ class Admin::FriendsController < AdminController
       :social_work_referral_notes,
       :no_record_in_eoir,
       :order_of_supervision,
+      :clinic_plan,
       language_ids: [],
       social_work_referral_category_ids: [],
       user_ids: []

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -40,6 +40,16 @@ class Friend < ApplicationRecord
                           appeal pending
                           motion_to_reopen_submitted].map { |status| [status.titlecase, status] }
 
+  CLINIC_PLANS = %w[i589
+                    individual_hearing
+                    motion_to_reopen
+                    appeal
+                    osup_rfi
+                    consultation
+                    foia
+                    change_of_venue
+                    work_permit].map{ |plan| [plan.titlecase, plan] }
+
   ASYLUM_APPLICATION_DEADLINE = 1.year
 
   belongs_to :community
@@ -72,6 +82,7 @@ class Friend < ApplicationRecord
   validates :a_number, length: { minimum: 8, maximum: 9 }, if: :a_number_available?
   validates_uniqueness_of :a_number, if: :a_number_available?
   validates :gender, presence: true, on: :create
+  validates :clinic_plan, inclusion: {in: CLINIC_PLANS.map(&:last)}, allow_blank: true
 
   scope :detained, -> { where(status: 'in_detention') }
 

--- a/app/views/admin/cohorts/_friend_assignment.html.erb
+++ b/app/views/admin/cohorts/_friend_assignment.html.erb
@@ -9,6 +9,7 @@
       <th />
       <th>Name</th>
       <th>Date of Entry</th>
+      <th>Clinic Plan</th>
       <th>Confirmed</th>
       <% @events.each do |event| %>
         <th><%= event.date.strftime("%-m/%-d") %></th>
@@ -34,6 +35,9 @@
         </td>
         <td>
           <%= assignment.friend.date_of_entry.try(:strftime, '%m/%d/%y') %>
+        </td>
+        <td>
+          <%= assignment.friend.clinic_plan&.titlecase %>
         </td>
         <td>
           <%= form_for [current_community, :admin, cohort, assignment]  do |f| %>

--- a/app/views/admin/friends/_clinic_form_fields.html.erb
+++ b/app/views/admin/friends/_clinic_form_fields.html.erb
@@ -45,6 +45,13 @@
   <% else %>
     <strong>Not yet assigned.</strong>
   <% end %>
+
+  <div class='row form-group'>
+    <%= f.label :clinic_plan, 'Clinic Plan', class: 'col-md-2 control-label' %>
+    <div class='col-md-6'>
+      <%= f.select :clinic_plan, options_for_select(Friend::CLINIC_PLANS, @friend.clinic_plan), {include_blank: true}, {class: 'form-control'} %>
+    </div>
+  </div>
 </div>
 
 <div class='form_fields_section'>

--- a/db/migrate/20200201173349_add_clinic_plan_to_friends.rb
+++ b/db/migrate/20200201173349_add_clinic_plan_to_friends.rb
@@ -1,0 +1,5 @@
+class AddClinicPlanToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :clinic_plan, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_18_051059) do
+ActiveRecord::Schema.define(version: 2020_02_01_173349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -266,6 +266,7 @@ ActiveRecord::Schema.define(version: 2020_01_18_051059) do
     t.boolean "famu_docket", default: false
     t.boolean "no_record_in_eoir", default: false
     t.boolean "order_of_supervision", default: false
+    t.string "clinic_plan"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"
   end

--- a/spec/features/community_admin/edit_a_friend_spec.rb
+++ b/spec/features/community_admin/edit_a_friend_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe 'Friend edit', type: :feature, js: true do
         end
         within '.tab-content' do
           expect(page).to have_content 'Asylum'
+          expect(page).to have_content 'Clinic Plan'
         end
       end
     end

--- a/spec/models/friend_spec.rb
+++ b/spec/models/friend_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Friend, type: :model do
   it { should validate_presence_of(:first_name) }
   it { should validate_presence_of(:last_name) }
   it { should validate_presence_of(:community_id) }
+  it { should validate_inclusion_of(:clinic_plan).in_array(%w(i589 individual_hearing motion_to_reopen appeal osup_rfi
+                                                              consultation foia change_of_venue work_permit)) }
+  it { should allow_value(nil).for(:clinic_plan) }
 
   describe 'validations' do
 


### PR DESCRIPTION
This implements https://github.com/CZagrobelny/new_sanctuary_asylum/issues/308 by allowing an admin to specify the "Clinic Plan" for a Friend, and displaying that plan on the Cohort page.

form field:
![dropdown](https://user-images.githubusercontent.com/1977279/73596788-8eb21a80-44f3-11ea-9d77-9930ba4c6c32.png)

cohort page:
![cohort](https://user-images.githubusercontent.com/1977279/73596755-3549eb80-44f3-11ea-979e-ae96b139ddea.png)