### PR TITLE
Add judge-imposed asylum application deadlines

### DIFF
--- a/app/controllers/accompaniment_leader/accompaniment_reports_controller.rb
+++ b/app/controllers/accompaniment_leader/accompaniment_reports_controller.rb
@@ -1,6 +1,6 @@
 class AccompanimentLeader::AccompanimentReportsController < AccompanimentLeaderController
   def new
-    @accompaniment_report = activity.accompaniment_reports.new
+    @accompaniment_report = activity.accompaniment_reports.new(friend: friend)
   end
 
   def edit
@@ -35,12 +35,17 @@ class AccompanimentLeader::AccompanimentReportsController < AccompanimentLeaderC
   def accompaniment_report_params
     params.require(:accompaniment_report).permit(
       :notes,
-      :outcome_of_hearing
-    ).merge(user_id: current_user.id)
+      :outcome_of_hearing,
+      friend_attributes: [:judge_imposed_i589_deadline]
+    ).merge(user_id: current_user.id, friend_id: friend.id)
   end
 
   def activity
     @activity ||= current_region.activities.find(params[:activity_id])
+  end
+
+  def friend
+    @friend ||= activity.friend
   end
 
   def accompaniment_report

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -138,6 +138,7 @@ class Admin::FriendsController < AdminController
       :no_record_in_eoir,
       :order_of_supervision,
       :clinic_plan,
+      :judge_imposed_i589_deadline,
       language_ids: [],
       social_work_referral_category_ids: [],
       user_ids: []

--- a/app/models/accompaniment_report.rb
+++ b/app/models/accompaniment_report.rb
@@ -1,5 +1,8 @@
 class AccompanimentReport < ApplicationRecord
   belongs_to :activity
   belongs_to :user
+  belongs_to :friend
   validates :notes, :activity_id, presence: true
+
+  accepts_nested_attributes_for :friend, update_only: true
 end

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -57,6 +57,7 @@ class Friend < ApplicationRecord
   has_many :friend_languages, dependent: :destroy
   has_many :languages, through: :friend_languages
   has_many :activities, dependent: :restrict_with_error
+  has_many :accompaniment_reports, dependent: :restrict_with_error
   has_many :detentions, dependent: :destroy
   has_many :ankle_monitors, dependent: :destroy
   has_many :user_friend_associations, dependent: :destroy

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -153,6 +153,14 @@ class Friend < ApplicationRecord
     where('date_of_entry <= ?', string_to_end_of_date(date) - ASYLUM_APPLICATION_DEADLINE)
   }
 
+  scope :filter_judge_imposed_deadline_ending_after, ->(date) {
+    where('judge_imposed_i589_deadline > ?', string_to_beginning_of_date(date))
+  }
+
+  scope :filter_judge_imposed_deadline_ending_before, ->(date) {
+    where('judge_imposed_i589_deadline <= ?', string_to_beginning_of_date(date))
+  }
+
   scope :filter_created_after, ->(date) {
     where('created_at >= ?', string_to_beginning_of_date(date))
   }
@@ -268,6 +276,8 @@ class Friend < ApplicationRecord
                                     filter_asylum_application_deadline_ending_before
                                     filter_created_after
                                     filter_created_before
+                                    filter_judge_imposed_deadline_ending_after
+                                    filter_judge_imposed_deadline_ending_before
                                     filter_application_status
                                     filter_phone_number
                                     filter_notes

--- a/app/views/accompaniment_leader/accompaniment_reports/_form.html.erb
+++ b/app/views/accompaniment_leader/accompaniment_reports/_form.html.erb
@@ -14,6 +14,15 @@
       </div>
     </div>
 
+    <%= f.fields_for :friend, @accompaniment_report.friend do |friend_f| %>
+      <div class='row form-group'>
+        <%= friend_f.label :judge_imposed_i589_deadline, 'Judge-imposed asylum application deadline', class: 'col-md-12 control-label' %>
+        <div class='col-md-12'>
+          <%= friend_f.text_field :judge_imposed_i589_deadline, class: 'datepicker form-control' %>
+        </div>
+      </div>
+    <% end %>
+
     <div class='row'>
       <div class='col-md-1 col-md-offset-11'>
         <%= f.submit 'Save', class: 'btn btn-primary' %>

--- a/app/views/admin/friends/_basic_form_fields.html.erb
+++ b/app/views/admin/friends/_basic_form_fields.html.erb
@@ -154,6 +154,13 @@
   </div>
 </div>
 
+<div class='row form-group'>
+  <%= f.label :judge_imposed_i589_deadline, 'Judge-imposed asylum application deadline', class: 'col-md-2 control-label' %>
+  <div class='col-md-6'>
+    <%= f.date_select :judge_imposed_i589_deadline, { start_year: Date.current.year, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
+  </div>
+</div>
+
 <h3>Family</h3>
 
 <% if @friend.persisted? %>

--- a/app/views/admin/friends/_search_friends.html.erb
+++ b/app/views/admin/friends/_search_friends.html.erb
@@ -98,17 +98,24 @@
     </div>
 
     <div class='form-group col-md-6'>
-      <%= f.label :country_of_origin, 'Country of origin:' %>
-      <%= f.select :country_of_origin, @filterrific.select_options[:country_of_origin], { include_blank: true }, multiple: true, class: 'chzn-select form-control' %>
+      <%= f.label :filter_start_date, 'Judge imposed deadline:' %>
+
+      <%= f.text_field :filter_judge_imposed_deadline_ending_after, class: 'datepicker form-control' %>
+      <%= f.text_field :filter_judge_imposed_deadline_ending_before, class: 'datepicker form-control' %>
     </div>
   </div>
 
   <div class='row'>
-    <div class='form-group col-md-12 inline-form-group'>
+    <div class='form-group col-md-6 inline-form-group'>
       <div>
         <%= f.label :sorted_by, 'Sorted by' %>
         <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], {}, { class: 'form-control' } %>
       </div>
+    </div>
+
+    <div class='form-group col-md-6'>
+      <%= f.label :country_of_origin, 'Country of origin:' %>
+      <%= f.select :country_of_origin, @filterrific.select_options[:country_of_origin], { include_blank: true }, multiple: true, class: 'chzn-select form-control' %>
     </div>
   </div>
 

--- a/db/migrate/20200318020814_add_judge_imposed_i589_deadline_to_friends.rb
+++ b/db/migrate/20200318020814_add_judge_imposed_i589_deadline_to_friends.rb
@@ -1,0 +1,5 @@
+class AddJudgeImposedI589DeadlineToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :judge_imposed_i589_deadline, :datetime
+  end
+end

--- a/db/migrate/20200401002007_add_friend_to_accompaniment_reports.rb
+++ b/db/migrate/20200401002007_add_friend_to_accompaniment_reports.rb
@@ -1,0 +1,14 @@
+class AddFriendToAccompanimentReports < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :accompaniment_reports, :friend, index: false
+
+    execute <<~SQL
+    UPDATE accompaniment_reports
+    SET friend_id = (SELECT friend_id FROM activities WHERE id = accompaniment_reports.activity_id)
+    SQL
+  end
+
+  def down
+    remove_reference :accompaniment_reports, :friend
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_18_020814) do
+ActiveRecord::Schema.define(version: 2020_04_01_002007) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_03_18_020814) do
     t.datetime "updated_at", null: false
     t.integer "user_id"
     t.text "outcome_of_hearing"
+    t.bigint "friend_id"
   end
 
   create_table "accompaniments", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_15_212329) do
+ActiveRecord::Schema.define(version: 2020_03_18_020814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -268,6 +268,7 @@ ActiveRecord::Schema.define(version: 2020_02_15_212329) do
     t.boolean "no_record_in_eoir", default: false
     t.boolean "order_of_supervision", default: false
     t.string "clinic_plan"
+    t.datetime "judge_imposed_i589_deadline"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"
   end

--- a/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
+++ b/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
@@ -44,10 +44,13 @@ RSpec.describe 'Accompaniment leader viewing and reporting on accompaniments', t
       it 'displays a flash message that my accompaniment leader notes were addded' do
         fill_in 'Outcome of hearing', with: 'outcome'
         fill_in 'Notes', with: 'Test notes'
+        fill_in 'Judge-imposed asylum application deadline', with: '5/31/2020'
         click_button 'Save'
         within '.alert' do
           expect(page).to have_content 'Your accompaniment leader notes were added.'
         end
+
+        expect(activity.friend.reload.judge_imposed_i589_deadline.to_date).to eq Date.new(2020, 5, 31)
       end
     end
 

--- a/spec/models/friend_spec.rb
+++ b/spec/models/friend_spec.rb
@@ -214,6 +214,52 @@ RSpec.describe Friend, type: :model do
     end
   end
 
+  describe '#filter_judge_imposed_deadline_ending_after' do
+    let(:friend) { create :friend, judge_imposed_i589_deadline: 2.months.from_now }
+    let(:safe_buffer_date) { ActiveSupport::SafeBuffer.new(date.to_s) }
+
+    context 'the filter is before the friend\'s deadline' do
+      let(:date) { friend.judge_imposed_i589_deadline - 1.week }
+
+      it 'returns the friend' do
+        expect(Friend.filter_judge_imposed_deadline_ending_after(safe_buffer_date))
+          .to contain_exactly friend
+      end
+    end
+
+    context 'the filter is after the friend\'s deadline' do
+      let(:date) { friend.judge_imposed_i589_deadline + 1.week }
+
+      it 'doesn\'t return the friend' do
+        expect(Friend.filter_judge_imposed_deadline_ending_after(safe_buffer_date))
+          .to be_empty
+      end
+    end
+  end
+
+  describe '#filter_judge_imposed_deadline_ending_before' do
+    let(:friend) { create :friend, judge_imposed_i589_deadline: 2.months.from_now }
+    let(:safe_buffer_date) { ActiveSupport::SafeBuffer.new(date.to_s) }
+
+    context 'the filter is before the friend\'s deadline' do
+      let(:date) { friend.judge_imposed_i589_deadline - 1.week }
+
+      it 'doesn\'t return the friend' do
+        expect(Friend.filter_judge_imposed_deadline_ending_before(safe_buffer_date))
+          .to be_empty
+      end
+    end
+
+    context 'the filter is after the friend\'s deadline' do
+      let(:date) { friend.judge_imposed_i589_deadline + 1.week }
+
+      it 'returns the friend' do
+        expect(Friend.filter_judge_imposed_deadline_ending_before(safe_buffer_date))
+          .to contain_exactly friend
+      end
+    end
+  end
+
   describe '#filter_created_after' do
     let(:friend) { create :friend }
     let(:safe_buffer_date) { ActiveSupport::SafeBuffer.new(date.to_s) }


### PR DESCRIPTION
This implements https://github.com/CZagrobelny/new_sanctuary_asylum/issues/302 by adding a `judge_imposed_i589_deadline` field to the Friend data model.

Admins can set this field on the Friend form:
![dates](https://user-images.githubusercontent.com/1977279/78087805-3b900300-7390-11ea-9300-75e3e930543e.png)

and filter the list of Friends based on a range of deadline dates:
![filter](https://user-images.githubusercontent.com/1977279/78087878-709c5580-7390-11ea-9ed6-e3528c0c53f3.png)

Also, an accompaniment leader submitting an accompaniment report can set or update the deadline:
![accompany](https://user-images.githubusercontent.com/1977279/78087937-a4777b00-7390-11ea-9158-7c6a08bab175.png)

## Implementation notes
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/302 suggested implementing the accompaniment leader functionality by letting the Friend model accept nested attributes for accompaniment reports. I initially tried this approach, but it ended up much less complex to go the other direction, and let the accompaniment report model accept nested attributes to update the Friend. Since we're restricting the list of permitted parameters, I don't think there's a risk of other Friend attributes being updated by accident.