### PR TITLE
Allow accompaniment leaders to specify whether a Friend has a lawyer, with simplified lawyer-info fields

### DIFF
--- a/app/controllers/accompaniment_leader/accompaniment_reports_controller.rb
+++ b/app/controllers/accompaniment_leader/accompaniment_reports_controller.rb
@@ -36,7 +36,7 @@ class AccompanimentLeader::AccompanimentReportsController < AccompanimentLeaderC
     params.require(:accompaniment_report).permit(
       :notes,
       :outcome_of_hearing,
-      friend_attributes: [:judge_imposed_i589_deadline]
+      friend_attributes: [:has_a_lawyer, :judge_imposed_i589_deadline, :lawyer_name]
     ).merge(user_id: current_user.id, friend_id: friend.id)
   end
 

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -139,6 +139,8 @@ class Admin::FriendsController < AdminController
       :order_of_supervision,
       :clinic_plan,
       :judge_imposed_i589_deadline,
+      :has_a_lawyer,
+      :lawyer_name,
       language_ids: [],
       social_work_referral_category_ids: [],
       user_ids: []

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -84,6 +84,7 @@ class Friend < ApplicationRecord
   validates_uniqueness_of :a_number, if: :a_number_available?
   validates :gender, presence: true, on: :create
   validates :clinic_plan, inclusion: {in: CLINIC_PLANS.map(&:last)}, allow_blank: true
+  validates :lawyer_name, presence: true, if: :has_a_lawyer?
 
   scope :detained, -> { where(status: 'in_detention') }
 

--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -137,6 +137,10 @@ class Friend < ApplicationRecord
     where(order_of_supervision: true) if order_of_supervision == 1
   }
 
+  scope :filter_has_a_lawyer, ->(has_a_lawyer) {
+    where(has_a_lawyer: true) if has_a_lawyer == 1
+  }
+
   scope :filter_must_be_seen_by_after, ->(date) {
     where('must_be_seen_by >= ?', string_to_beginning_of_date(date))
   }
@@ -291,6 +295,7 @@ class Friend < ApplicationRecord
                                     activity_location
                                     filter_no_record_in_eoir
                                     filter_order_of_supervision
+                                    filter_has_a_lawyer
                                     country_of_origin
                                   ])
 

--- a/app/views/accompaniment_leader/accompaniment_reports/_form.html.erb
+++ b/app/views/accompaniment_leader/accompaniment_reports/_form.html.erb
@@ -21,6 +21,17 @@
           <%= friend_f.text_field :judge_imposed_i589_deadline, class: 'datepicker form-control' %>
         </div>
       </div>
+
+      <div class='row form-group form-inline'>
+        <div class='col-md-4'>
+          <%= friend_f.check_box :has_a_lawyer %>
+          <%= friend_f.label :has_a_lawyer, 'Has a Lawyer' %>
+        </div>
+        <div class='col-md-8'>
+          <%= friend_f.label :lawyer_name, 'Lawyer Name', class: 'control-label' %>
+          <%= friend_f.text_field :lawyer_name, class: 'form-control' %>
+        </div>
+      </div>
     <% end %>
 
     <div class='row'>

--- a/app/views/admin/friends/_other_case_info_form_fields.html.erb
+++ b/app/views/admin/friends/_other_case_info_form_fields.html.erb
@@ -20,6 +20,20 @@
   <h3>Lawyer</h3>
 
   <div class='row form-group'>
+    <div class='col-md-12'>
+      <%= f.check_box :has_a_lawyer %>
+      <%= f.label :has_a_lawyer, 'Has a Lawyer' %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
+    <%= f.label :lawyer_name, 'Lawyer Name', class: 'col-md-2 control-label' %>
+    <div class='col-md-4'>
+      <%= f.text_field :lawyer_name, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class='row form-group'>
     <%= f.label :lawyer_referred_to,'Referred to', class: 'col-md-2 control-label' %>
     <div class='col-md-6'>
       <%= collection_select(:friend, :lawyer_referred_to, current_region.lawyers.order('organization asc'), :id, :name_and_organization, {include_blank: true}, {class: 'form-control chzn-select'}) %>

--- a/app/views/admin/friends/_search_friends.html.erb
+++ b/app/views/admin/friends/_search_friends.html.erb
@@ -51,7 +51,10 @@
       <%= f.label :filter_order_of_supervision, 'OSUP' %>
       <%= f.check_box(:filter_order_of_supervision) %>
     </div>
-
+    <div class='form-group col-md-2 inline-form-group'>
+      <%= f.label :filter_has_a_lawyer, 'Has a lawyer' %>
+      <%= f.check_box(:filter_has_a_lawyer) %>
+    </div>
   </div>
 
   <div class="row">

--- a/db/migrate/20200419151613_add_lawyer_info_to_friends.rb
+++ b/db/migrate/20200419151613_add_lawyer_info_to_friends.rb
@@ -1,0 +1,6 @@
+class AddLawyerInfoToFriends < ActiveRecord::Migration[5.2]
+  def change
+    add_column :friends, :has_a_lawyer, :boolean
+    add_column :friends, :lawyer_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_01_002007) do
+ActiveRecord::Schema.define(version: 2020_04_19_151613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -270,6 +270,8 @@ ActiveRecord::Schema.define(version: 2020_04_01_002007) do
     t.boolean "order_of_supervision", default: false
     t.string "clinic_plan"
     t.datetime "judge_imposed_i589_deadline"
+    t.boolean "has_a_lawyer"
+    t.string "lawyer_name"
     t.index ["community_id"], name: "index_friends_on_community_id"
     t.index ["region_id"], name: "index_friends_on_region_id"
   end

--- a/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
+++ b/spec/features/accompaniment_leader/viewing_and_reporting_on_accompaniments_spec.rb
@@ -45,12 +45,17 @@ RSpec.describe 'Accompaniment leader viewing and reporting on accompaniments', t
         fill_in 'Outcome of hearing', with: 'outcome'
         fill_in 'Notes', with: 'Test notes'
         fill_in 'Judge-imposed asylum application deadline', with: '5/31/2020'
+        check 'Has a Lawyer'
+        fill_in 'Lawyer Name', with: 'Susan Example'
         click_button 'Save'
         within '.alert' do
           expect(page).to have_content 'Your accompaniment leader notes were added.'
         end
 
-        expect(activity.friend.reload.judge_imposed_i589_deadline.to_date).to eq Date.new(2020, 5, 31)
+        updated_friend = activity.friend.reload
+        expect(updated_friend.judge_imposed_i589_deadline.to_date).to eq Date.new(2020, 5, 31)
+        expect(updated_friend.has_a_lawyer?).to be_truthy
+        expect(updated_friend.lawyer_name).to eq 'Susan Example'
       end
     end
 

--- a/spec/models/friend_spec.rb
+++ b/spec/models/friend_spec.rb
@@ -163,6 +163,19 @@ RSpec.describe Friend, type: :model do
     end
   end
 
+  describe '#filter_has_a_lawyer' do
+    let!(:friend_with_lawyer) { create :friend, has_a_lawyer: true, lawyer_name: 'Susan Q. Example' }
+    let!(:friend_without_lawyer) { create :friend, has_a_lawyer: false }
+
+    it 'returns the friend with a lawyer if 1' do
+      expect(Friend.filter_has_a_lawyer(1)).to contain_exactly(friend_with_lawyer)
+    end
+
+    it 'returns all friends if not 1' do
+      expect(Friend.filter_has_a_lawyer(0)).to contain_exactly(friend_with_lawyer, friend_without_lawyer)
+    end
+  end
+
   describe '#filter_first_name' do
     let(:friend) { create :friend, first_name: "Cat"}
     

--- a/spec/models/friend_spec.rb
+++ b/spec/models/friend_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe Friend, type: :model do
     context 'zip_code is invalid if not a number' do
       it { should validate_numericality_of(:zip_code) }
     end
+
+    context 'has_a_lawyer is true' do
+      before { friend.has_a_lawyer = true }
+
+      it { should validate_presence_of(:lawyer_name) }
+    end
+
+    context 'has_a_lawyer is false' do
+      before { friend.has_a_lawyer = false }
+
+      it { should_not validate_presence_of(:lawyer_name) }
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
This implements https://github.com/CZagrobelny/new_sanctuary_asylum/issues/305 by adding `has_a_lawyer` and `lawyer_name` to the Friend data model.

An accompaniment leader submitting an accompaniment report can update these fields:
![lawyer-row](https://user-images.githubusercontent.com/1977279/79692834-58a04f00-8235-11ea-80e6-3f70e1ad1a7f.png)

An admin can filter the list of Friends to find only Friends with lawyers:
![filter](https://user-images.githubusercontent.com/1977279/79692941-feec5480-8235-11ea-8367-482259561a12.png)

and can edit a Friend's lawyer info:
![edi](https://user-images.githubusercontent.com/1977279/79692963-19263280-8236-11ea-97d9-9f690c35b26c.png)


### Implementation notes
- I named the field "lawyer name", but I'm not actually sure from https://github.com/CZagrobelny/new_sanctuary_asylum/issues/305 whether it's supposed to be "lawyer info" instead. Happy to change it if "lawyer info" is the correct name.
- I added a validation to ensure that if "Has a Lawyer" is checked, then "Lawyer Name" must be filled in. Is this correct, or might an accompaniment leader know that the Friend has a lawyer but not know the lawyer's name?