### PR TITLE
Fix docker

### DIFF
--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -11,7 +11,6 @@ Confirm docker is installed by typing `docker info` in your terminal.
 ### Setup files
 
 * Ensure you have a `.env` file (see `README.md` for details.)
-* Set your `database.yml`: `cp config/database_docker.yml.sample config/database.yml`
 * Add this line to `.env`: `POSTGRES_PASSWORD=password`
 
 ### Building The Image

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -8,23 +8,24 @@ Confirm docker is installed by typing `docker info` in your terminal.
 
 ## Using Docker
 
+### Setup files
+
+* Ensure you have a `.env` file (see `README.md` for details.)
+* Set your `database.yml`: `cp config/database_docker.yml.sample config/database.yml`
+* Add this line to `.env`: `POSTGRES_PASSWORD=password`
+
 ### Building The Image
 The first time you run the application in docker, you need to build the docker-compose image. This will create a static artifact that will be used to start the containers. You only need to build once, or if you change the Dockerfile, docker-compose.yml file, or make changes to the database.
 
-Run:
-```
-docker-compose -f docker-compose.yml build
-```
-
-On a mac, you can shorten this by running `make build`, which is defined in the [Makefile](Makefile).
+Run `make build`.
 
 ### To Start and Run the Containers
 Now that the image has been build, we need to start the containers for the web application and the database. We do this with the `up` command.
 
-Run: `docker-compose -f docker-compose.yml up` or `make up` (for macs).
+Run `make up`.
 
 ### To Stop the Containers
-To stop your running container process, press `ctrl+c`. To bring down the containers cleanly, run `docker-compose -f docker-compose.yml down` or `make down` (for macs).
+To stop your running container process, press `ctrl+c`. To bring down the containers cleanly, run `make down`.
 
 To confirm the containers have stopped, you can take a look with `docker ps` -- the output should be empty.
 
@@ -41,7 +42,7 @@ Run: `docker exec -it sanctuary_web /bin/bash` then `rails c`.
 
 #### To Run Rspec
 To interactively run tests, run: `docker exec -it sanctuary_web /bin/bash` then `rspec .`.
-To just see test results, run: `docker exec -it sanctuary_web rspec` or `make test` (for macs).
+To just see test results, run: `docker exec -it sanctuary_web rspec` or `make test`.
 
 #### To Open a PSQL Console
 Run: `docker exec -it sanctuary_db psql -U postgres`
@@ -50,13 +51,14 @@ Some shortcuts for using PSQL: [cheatsheet](https://gist.github.com/Kartones/dd3
 
 
 ## Docker Troubleshooting
-To start from scratch completely and eliminate previously-built images, run `docker-compose -f docker-compose.yml down --rmi all` or `make down_clean` (for macs).
+To start from scratch completely and eliminate previously-built images, run `make down_clean`.
 
-If you get the error `A server is already running. Check /tmp/sanctuary/tmp/pids/server.pid`, in another tab run
+If you get the error `A server is already running. Check /tmp/sanctuary/tmp/pids/server.pid`, in another tab run:
 
 ```
 docker start sanctuary_web; docker exec sanctuary_web rm /sanctuary/tmp/pids/server.pid
 ```
+
 and the container should restart with a new pid.
 
 ## Running the Application Without Docker (after running it WITH Docker)

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -17,14 +17,18 @@ Confirm docker is installed by typing `docker info` in your terminal.
 The first time you run the application in docker, you need to build the docker-compose image. This will create a static artifact that will be used to start the containers. You only need to build once, or if you change the Dockerfile, docker-compose.yml file, or make changes to the database.
 
 Run `make build`.
+If you are on Windows, `make` commands may not work.
+Windows OS: `docker-compose -f docker-compose.yml build`
 
 ### To Start and Run the Containers
 Now that the image has been build, we need to start the containers for the web application and the database. We do this with the `up` command.
 
 Run `make up`.
+Windows OS: `docker-compose -f docker-compose.yml up`
 
 ### To Stop the Containers
 To stop your running container process, press `ctrl+c`. To bring down the containers cleanly, run `make down`.
+Windows OS: `docker-compose -f docker-compose.yml down`
 
 To confirm the containers have stopped, you can take a look with `docker ps` -- the output should be empty.
 
@@ -51,6 +55,7 @@ Some shortcuts for using PSQL: [cheatsheet](https://gist.github.com/Kartones/dd3
 
 ## Docker Troubleshooting
 To start from scratch completely and eliminate previously-built images, run `make down_clean`.
+Windows OS: `docker-compose -f docker-compose.yml down --rmi all`
 
 If you get the error `A server is already running. Check /tmp/sanctuary/tmp/pids/server.pid`, in another tab run:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 FROM ruby:2.6.6
+
+# needed to be able to pull postgresql-client-9.6 below
+RUN apt-get install curl ca-certificates gnupg
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get update -qq && apt-get install -y lsb-release
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
 RUN apt-get update -qq \
     && apt-get install -y --no-install-recommends \
     libpq-dev \

--- a/config/database_docker.yml.sample
+++ b/config/database_docker.yml.sample
@@ -1,5 +1,3 @@
-production:
-
 development:
   user: postgres
   password: password


### PR DESCRIPTION
## Why is this PR needed?

The update to ruby 2.6.6 breaks our docker-compose functionality. This restores it.

## Solution

* Configure the docker image to pull pg 9.6
* Fix config no longer working with new version of rails
* Update docker readme with linux docker setup
