### PR TITLE
Added `ampm` to all datetime fields

### DIFF
--- a/app/views/accompaniment_leader/friends/activities/_form.html.erb
+++ b/app/views/accompaniment_leader/friends/activities/_form.html.erb
@@ -36,7 +36,7 @@
       <%= f.label :occur_at, 'Date/Time', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
         <%= f.date_select :occur_at, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>
@@ -45,7 +45,7 @@
       <%= f.label :control_date, 'Control Date', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
         <%= f.date_select :control_date, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>

--- a/app/views/admin/activities/_form.html.erb
+++ b/app/views/admin/activities/_form.html.erb
@@ -36,7 +36,7 @@
       <%= f.label :occur_at, 'Date/Time', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
         <%= f.date_select :occur_at, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>
@@ -45,7 +45,7 @@
       <%= f.label :control_date, 'Control Date', class: 'col-md-3 col-xs-12 control-label' %>
       <div class='col-md-6 col-xs-12'>
         <%= f.date_select :control_date, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -21,7 +21,7 @@
       <%= f.label :date, 'Date/Time', class: 'col-md-2 control-label required' %>
       <div class='col-md-8'>
         <%= f.date_select :date, { start_year: 2017, end_year: 1.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :date, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :date, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>

--- a/app/views/admin/friends/activities/_form.html.erb
+++ b/app/views/admin/friends/activities/_form.html.erb
@@ -29,7 +29,7 @@
       <%= f.label :occur_at, 'Date/Time', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
         <%= f.date_select :occur_at, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>
@@ -38,7 +38,7 @@
       <%= f.label :control_date, 'Control Date', class: 'col-md-12 col-xs-12 control-label' %>
       <div class='col-md-12 col-xs-12'>
         <%= f.date_select :control_date, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>

--- a/app/views/eoir_caller/friends/activities/_form.html.erb
+++ b/app/views/eoir_caller/friends/activities/_form.html.erb
@@ -30,7 +30,7 @@
       <%= f.label :occur_at, 'Date/Time', class: 'col-md-12 control-label' %>
       <div class='col-md-12'>
         <%= f.date_select :occur_at, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :occur_at, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>
@@ -39,7 +39,7 @@
       <%= f.label :control_date, 'Control Date', class: 'col-md-12 col-xs-12 control-label' %>
       <div class='col-md-12 col-xs-12'>
         <%= f.date_select :control_date, { start_year: 2017, end_year: 5.years.from_now.year, prompt: true, order: [:month, :day, :year] }, {class: 'form-control inline-date-select'} %>
-        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15 }, {class: 'form-control inline-date-select'} %>
+        <%= f.time_select :control_date, { ignore_date: true, prompt: true, minute_step: 15, ampm: true }, {class: 'form-control inline-date-select'} %>
         <span>ET
       </div>
     </div>


### PR DESCRIPTION
## Why is this PR needed?

Adds an `ampm` field to all datetimes, so they don't render as military time.
