### PR TITLE
add devise authy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'carrierwave'
 gem 'carrierwave-aws'
 gem 'chartkick'
 gem 'devise'
+gem 'devise-authy'
 gem 'devise_invitable'
 gem 'devise-security'
 gem 'faker' # used for seed data on staging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     american_date (1.1.1)
     ast (2.4.1)
+    authy (2.7.5)
+      httpclient (>= 2.5.3.3)
     aws-eventstream (1.1.0)
     aws-partitions (1.371.0)
     aws-sdk-core (3.107.0)
@@ -116,6 +118,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-authy (2.2.1)
+      authy (>= 2.7.5)
+      devise (>= 4.0.0)
     devise-security (0.14.3)
       devise (>= 4.3.0, < 5.0)
       rails (>= 4.2.0, < 7.0)
@@ -142,6 +147,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.1)
+    httpclient (2.8.3)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_processing (1.11.0)
@@ -348,6 +354,7 @@ DEPENDENCIES
   chartkick
   database_cleaner
   devise
+  devise-authy
   devise-security
   devise_invitable
   dotenv-rails

--- a/app/assets/javascripts/devise_authy.js
+++ b/app/assets/javascripts/devise_authy.js
@@ -1,0 +1,12 @@
+$(document).ready(function() {
+  $('a#authy-request-sms-link').unbind('ajax:success');
+  $('a#authy-request-sms-link').bind('ajax:success', function(evt, data, status, xhr) {
+    alert(data.message);
+  });
+
+  $('a#authy-request-phone-call-link').unbind('ajax:success');
+  $('a#authy-request-phone-call-link').bind('ajax:success', function(evt, data, status, xhr) {
+    alert(data.message);
+  });
+});
+

--- a/app/assets/stylesheets/devise_authy.css
+++ b/app/assets/stylesheets/devise_authy.css
@@ -1,0 +1,26 @@
+.devise_authy {
+  margin-left: auto;
+  margin-right: auto;
+  width: 350px;
+}
+
+.authy-form legend {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 20px;
+  font-size: 21px;
+  line-height: 40px;
+  color: #333;
+  border-bottom: 1px solid #E5E5E5;
+}
+
+.authy-form label,
+.authy-form input,
+.authy-form button {
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 20px;
+  padding: 8px;
+  margin: 8px;
+}

--- a/app/controllers/admin/friends_controller.rb
+++ b/app/controllers/admin/friends_controller.rb
@@ -29,7 +29,7 @@ class Admin::FriendsController < AdminController
 
     @friends = current_community.friends
       .filterrific_find(@filterrific)
-      .paginate(page: params[:page])
+      .paginate(page: params[:page], per_page: 10)
   end
 
   def new

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,9 +7,11 @@ class AdminController < ApplicationController
   private
 
   def log_action
+    did_use_2fac = session['user_authy_token_checked'];
     Rails.logger.info "ADMIN [#{current_user.email}, "\
+    "Used Authy to 2fac: #{did_use_2fac ? 'YES' : 'NO'}, "\
     "ip: #{request.remote_ip}]:  #{request_path_parameters} "\
-    "#{request_query_parameters}"
+    "#{request_query_parameters} "
   end
 
   def request_path_parameters

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,9 +8,9 @@ class AdminController < ApplicationController
 
   def log_action
     did_use_2fac = session['user_authy_token_checked'];
-    Rails.logger.info "ADMIN [#{current_user.email}, "\
-    "Used Authy to 2fac: #{did_use_2fac ? 'YES' : 'NO'}, "\
-    "ip: #{request.remote_ip}]:  #{request_path_parameters} "\
+    Rails.logger.info "ADMIN [email=#{current_user.email}, "\
+    "Used Authy to 2fac= #{did_use_2fac ? 'YES' : 'NO'}, "\
+    "ip=#{request.remote_ip}]:  #{request_path_parameters} "\
     "#{request_query_parameters} "
   end
 

--- a/app/controllers/concerns/devise_overrides/devise_authy_controllers_helpers.rb
+++ b/app/controllers/concerns/devise_overrides/devise_authy_controllers_helpers.rb
@@ -1,0 +1,30 @@
+module DeviseOverrides
+  module DeviseAuthyControllersHelpers
+
+    private
+    def require_token?
+      id = warden.session(resource_name)[:id]
+      cookie = cookies.signed[:remember_device]
+      return true if cookie.blank?
+
+      # require token for old cookies which just have expiration time and no id
+      return true if cookie.to_s =~ %r{\A\d+\z}
+
+      cookie = JSON.parse(cookie) rescue ""
+      return true if cookie.blank?
+
+      cookie_set_at = cookie['expires'].to_i
+
+      # Overriding to require 2FA token for all cookies created before a user's password changed
+      return true if cookie_set_prior_to_password_change?(cookie_set_at: cookie_set_at, id: id)
+
+      (Time.now.to_i - cookie_set_at) > resource_class.authy_remember_device.to_i ||
+        cookie['id'] != id
+    end
+
+    def cookie_set_prior_to_password_change?(cookie_set_at:, id:)
+      resource = resource_class.find(id)
+      cookie_set_at < resource.password_changed_at.to_i
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
   private
 
   def user
-    @user ||= current_community.users.find(params[:id])
+    @user ||= current_user
   end
 
   def user_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,10 +17,10 @@ class User < ApplicationRecord
   # The users who can attend accompaniments (NOT as accompaniment leaders)
   ACCOMPANIMENT_ELIGIBLE_ROLES = %w[volunteer data_entry eoir_caller].freeze
 
-  devise :invitable, :database_authenticatable, :lockable,
-         :recoverable, :rememberable, :trackable, :secure_validatable,
-         :password_expirable, :password_archivable, :timeoutable,
-         :session_limitable, invite_for: 1.week
+  devise :invitable, :database_authenticatable, :authy_authenticatable,
+    :lockable, :authy_lockable, :recoverable, :rememberable, :trackable,
+    :secure_validatable, :password_expirable, :password_archivable,
+    :timeoutable, :session_limitable, invite_for: 1.week
 
   attr_reader :raw_invitation_token
 

--- a/app/views/devise/devise_authy/enable_authy.html.erb
+++ b/app/views/devise/devise_authy/enable_authy.html.erb
@@ -1,0 +1,7 @@
+<h2><%= I18n.t('authy_register_title', {:scope => 'devise'}) %></h2>
+
+<%= enable_authy_form do %>
+  <%= text_field_tag :country_code, '', :autocomplete => :off, :placeholder => I18n.t('devise.country'), :id => "authy-countries"%>
+  <%= text_field_tag :cellphone, '', :autocomplete => :off, :placeholder => I18n.t('devise.cellphone'), :id => "authy-cellphone"%>
+  <p><%= submit_tag I18n.t('enable_authy', {:scope => 'devise'}) %></p>
+<% end %>

--- a/app/views/devise/devise_authy/enable_authy.html.erb
+++ b/app/views/devise/devise_authy/enable_authy.html.erb
@@ -1,5 +1,7 @@
 <h2><%= I18n.t('authy_register_title', {:scope => 'devise'}) %></h2>
 
+<p>If you do not see a dropdown list of countries, refresh the page.</p>
+
 <%= enable_authy_form do %>
   <%= text_field_tag :country_code, '', :autocomplete => :off, :placeholder => I18n.t('devise.country'), :id => "authy-countries"%>
   <%= text_field_tag :cellphone, '', :autocomplete => :off, :placeholder => I18n.t('devise.cellphone'), :id => "authy-cellphone"%>

--- a/app/views/devise/devise_authy/verify_authy.html.erb
+++ b/app/views/devise/devise_authy/verify_authy.html.erb
@@ -1,0 +1,38 @@
+<h2>
+  <%= I18n.t('submit_token_title', {:scope => 'devise'}) %>
+</h2>
+
+<%= verify_authy_form do %>
+  <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
+  <%= label_tag 'authy-token' %>
+  <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
+  <label>
+    <%= check_box_tag :remember_device %>
+    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+  </label>
+
+  <!-- Help tooltip -->
+  <!-- You need to configure a help message. -->
+  <!-- See documentation: https://github.com/authy/authy-form-helpers#help-tooltip -->
+  <!-- <%= link_to '?', '#', :id => 'authy-help' %> -->
+
+  <%= authy_request_sms_link %>
+  <%= submit_tag I18n.t('submit_token', {:scope => 'devise'}), :class => 'btn' %>
+<% end %>
+
+<% if @onetouch_uuid %>
+    <script>
+      (function(){
+        var onetouchInterval = setInterval(function(){
+          var onetouchRequest = new XMLHttpRequest();
+          var rememberDevice = document.getElementById("remember_device").checked ? '1' : '0';
+          onetouchRequest.addEventListener("load", function(){
+            if(this.status != 202) clearInterval(onetouchInterval);
+            if(this.status == 200) window.location = JSON.parse(this.responseText).redirect;
+          });
+          onetouchRequest.open("GET", "<%= polymorphic_path [resource_name, :authy_onetouch_status] %>?remember_device="+rememberDevice+"&onetouch_uuid=<%= @onetouch_uuid %>");
+          onetouchRequest.send();
+        }, 3000);
+      })();
+    </script>
+<% end %>

--- a/app/views/devise/devise_authy/verify_authy.html.erb
+++ b/app/views/devise/devise_authy/verify_authy.html.erb
@@ -17,7 +17,7 @@
         If not, BAIL NOW and switch to the device that you own and the browser that you habitually use when working with the NSC database software!
       </span>
     </li>
-    <li>
+    <li style='margin-bottom: 10px;'>
       Should you be prompted for 2 Factor Authentication?<br>
       You will be prompted to enter your Authy code IF:
       <ul>
@@ -31,6 +31,18 @@
           You changed your password since the last time you logged in and entered your Authy code.
         </li>
       </ul>
+    </li>
+    <li style='margin-bottom: 10px;'>
+      If your Authy code is not accepted, try one more time (carefully checking that the code you are entering is correct and not expired).<br>
+      <span class='text-danger'>
+        If the second attempt fails, immediately lock down your account (the lock down link will NEVER be provided here).
+      </span>
+    </li>
+    <li style='margin-bottom: 10px;'>
+      If your Authy code is accepted, but once you are in the application you find that the data does not look quite right.<br>
+      <span class='text-danger'>
+        Immediately lock down your account (the lock down link will NEVER be provided here).
+      </span>
     </li>
   </ol>
 </strong>

--- a/app/views/devise/devise_authy/verify_authy.html.erb
+++ b/app/views/devise/devise_authy/verify_authy.html.erb
@@ -1,14 +1,47 @@
 <h2>
-  <%= I18n.t('submit_token_title', {:scope => 'devise'}) %>
+  <span class='text-danger'>STOP!</span>
+  And review this checklist:
 </h2>
 
+<strong>
+  <ol>
+    <li style='margin-bottom: 10px;'>
+      How did you navigate to the previous login page?<br>
+      <span class='text-danger'>
+        If you clicked on a link, BAIL NOW and DO NOT enter your Authy code below!
+      </span>
+    </li>
+    <li style='margin-bottom: 10px;'>
+      Are you using a device that you own and the browser that you habitually use when working with the NSC database software?<br>
+      <span class='text-danger'>
+        If not, BAIL NOW and switch to the device that you own and the browser that you habitually use when working with the NSC database software!
+      </span>
+    </li>
+    <li>
+      Should you be prompted for 2 Factor Authentication?<br>
+      You will be prompted to enter your Authy code IF:
+      <ul>
+        <li>
+          You previously allowed Authy to remember your browser/device for 1 week, and that 1 week has passed.
+        </li>
+        <li>
+          You did NOT allow Authy to remember your browser/device for 1 week when you last entered your Authy code.
+        </li>
+        <li>
+          You changed your password since the last time you logged in and entered your Authy code.
+        </li>
+      </ul>
+    </li>
+  </ol>
+</strong>
+
 <%= verify_authy_form do %>
-  <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
+  <legend>Thank you for taking the time to keep our data secure, you may now enter your Authy code:</legend>
   <%= label_tag 'authy-token' %>
   <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
   <label>
     <%= check_box_tag :remember_device %>
-    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+    <span>Remember this device for 1 week</span>
   </label>
 
   <!-- Help tooltip -->

--- a/app/views/devise/devise_authy/verify_authy_installation.html.erb
+++ b/app/views/devise/devise_authy/verify_authy_installation.html.erb
@@ -1,0 +1,18 @@
+<h2><%= I18n.t('authy_verify_installation_title', {:scope => 'devise'}) %></h2>
+
+<% if @authy_qr_code %>
+  <%= image_tag @authy_qr_code, :size => '256x256', :alt => I18n.t('authy_qr_code_alt', {:scope => 'devise'}) %>
+  <p><%= I18n.t('authy_qr_code_instructions', {:scope => 'devise'}) %></p>
+<% end %>
+
+<%= verify_authy_installation_form do %>
+  <legend><%= I18n.t('submit_token_title', {:scope => 'devise'}) %></legend>
+  <%= label_tag :token %>
+  <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
+  <label>
+    <%= check_box_tag :remember_device %>
+    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+  </label>
+  <%= authy_request_sms_link %>
+  <%= submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn' %>
+<% end %>

--- a/app/views/devise/devise_authy/verify_authy_installation.html.erb
+++ b/app/views/devise/devise_authy/verify_authy_installation.html.erb
@@ -11,7 +11,7 @@
   <%= text_field_tag :token, "", :autocomplete => "one-time-code", :inputmode => "numeric", :pattern => "[0-9]*", :id => 'authy-token' %>
   <label>
     <%= check_box_tag :remember_device %>
-    <span><%= I18n.t('remember_device', {:scope => 'devise'}) %></span>
+    <span>Remember this device for 1 week</span>
   </label>
   <%= authy_request_sms_link %>
   <%= submit_tag I18n.t('enable_my_account', {:scope => 'devise'}), :class => 'btn' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,9 @@
     <%= stylesheet_link_tag 'application', 'https://use.fontawesome.com/releases/v5.3.1/css/all.css' %>
     <%= csrf_meta_tags %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <%=javascript_include_tag "https://www.authy.com/form.authy.min.js" %>
+  <%=stylesheet_link_tag "https://www.authy.com/form.authy.min.css" %>
+
   </head>
   <body>
     <%= render 'shared/header' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,3 +1,10 @@
+<div class='pull-right'>
+  <% if @user.authy_enabled %>
+    <%= button_to 'Disable Two Factor Authentication', user_disable_authy_path, class: 'btn btn-danger' %>
+  <% else %>
+    <%= link_to 'Enable Two Factor Authentication', user_enable_authy_path, class: 'btn btn-success' %>
+  <% end %>
+</div>
 <div class='col-md-offset-3'>
   <h1>My Information</h1>
   <%= render 'form' %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,10 +1,13 @@
-<div class='pull-right'>
-  <% if @user.authy_enabled %>
-    <%= button_to 'Disable Two Factor Authentication', user_disable_authy_path, class: 'btn btn-danger' %>
-  <% else %>
-    <%= link_to 'Enable Two Factor Authentication', user_enable_authy_path, class: 'btn btn-success' %>
-  <% end %>
-</div>
+<% if ENV['AUTHY_API_KEY'] && (@user.admin? || @user.data_entry?) %>
+  <div class='pull-right'>
+    <% if @user.authy_enabled %>
+      <%= button_to 'Disable Two Factor Authentication', user_disable_authy_path, class: 'btn btn-danger' %>
+    <% else %>
+      <%= link_to 'Enable Two Factor Authentication', user_enable_authy_path, class: 'btn btn-success' %>
+    <% end %>
+  </div>
+<% end %>
+
 <div class='col-md-offset-3'>
   <h1>My Information</h1>
   <%= render 'form' %>

--- a/config/initializers/authy.rb
+++ b/config/initializers/authy.rb
@@ -1,0 +1,2 @@
+Authy.api_key = ENV["AUTHY_API_KEY"]
+Authy.api_uri = "https://api.authy.com/"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
 
   # ==> Devise Authy Authentication Extension
   # How long should the user's device be remembered for.
-  # config.authy_remember_device = 1.month
+  config.authy_remember_device = 1.week
 
   # Should Authy OneTouch be enabled?
   # config.authy_enable_onetouch = false
@@ -322,7 +322,7 @@ Devise.setup do |config|
   # end
 
   Warden::Manager.after_authentication do |user,auth,opts|
-    Rails.logger.info "Forensics Login Successful: user=#{user.email}"
+    Rails.logger.info "Forensics Login Successful: email=#{user.email}"
   end
 
   Warden::Manager.before_failure do |env, opts|
@@ -335,7 +335,7 @@ Devise.setup do |config|
   end
 
   Warden::Manager.before_logout do |user,auth,opts|
-    Rails.logger.info "Forensics Logout: user=#{user.email}" if user.present?
+    Rails.logger.info "Forensics Logout: email=#{user.email}" if user.present?
   end
 
   # ==> Mountable engine configurations

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,18 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+
+  # ==> Devise Authy Authentication Extension
+  # How long should the user's device be remembered for.
+  # config.authy_remember_device = 1.month
+
+  # Should Authy OneTouch be enabled?
+  # config.authy_enable_onetouch = false
+
+  # Should generating QR codes for other authenticator apps be enabled?
+  # Note: you need to enable this in your Twilio console.
+  # config.authy_enable_qr_code = false
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.

--- a/config/initializers/devise_concern_overrides.rb
+++ b/config/initializers/devise_concern_overrides.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file.
+
+ActiveSupport.on_load(:action_controller) do
+  include DeviseOverrides::DeviseAuthyControllersHelpers
+end

--- a/config/locales/devise.authy.en.yml
+++ b/config/locales/devise.authy.en.yml
@@ -1,0 +1,28 @@
+en:
+  devise:
+    submit_token: 'Check Token'
+    submit_token_title: 'Please enter your Authy token:'
+    authy_register_title: 'Enable Two factor authentication'
+    enable_authy: 'Enable'
+    cellphone: 'Enter your cellphone'
+    country: 'Enter your country'
+    request_sms: 'Request SMS'
+    request_phone_call: 'Request phone call'
+    remember_device: 'Remember Device'
+    request_to_login: 'Request to Login'
+
+    authy_verify_installation_title: 'Verify your account'
+    enable_my_account: 'Enable my account'
+
+    authy_qr_code_alt: 'QR code for scanning with your authenticator app.'
+    authy_qr_code_instructions: 'Scan this QR code with your authenticator application and enter the code below.'
+
+    devise_authy:
+      user:
+        enabled: 'Two factor authentication was enabled'
+        not_enabled: 'Something went wrong while enabling two factor authentication'
+        disabled: 'Two factor authentication was disabled'
+        not_disabled: 'Something went wrong while disabling two factor authentication'
+        signed_in: 'Signed in with Authy successfully.'
+        already_enabled: 'Two factor authentication is already enabled.'
+        invalid_token: 'The entered token is invalid'

--- a/db/migrate/20170408203714_devise_invitable_add_to_users.rb
+++ b/db/migrate/20170408203714_devise_invitable_add_to_users.rb
@@ -1,4 +1,4 @@
-class DeviseInvitableAddToUsers < ActiveRecord::Migration
+class DeviseInvitableAddToUsers < ActiveRecord::Migration[5.0]
   def up
     change_table :users do |t|
       t.string     :invitation_token

--- a/db/migrate/20201213170831_devise_authy_add_to_users.rb
+++ b/db/migrate/20201213170831_devise_authy_add_to_users.rb
@@ -1,0 +1,18 @@
+class DeviseAuthyAddToUsers < ActiveRecord::Migration[6.0]
+  def self.up
+    change_table :users do |t|
+      t.string    :authy_id
+      t.datetime  :last_sign_in_with_authy
+      t.boolean   :authy_enabled, :default => false
+    end
+
+    add_index :users, :authy_id
+  end
+
+  def self.down
+    change_table :users do |t|
+      t.remove :authy_id, :last_sign_in_with_authy, :authy_enabled
+    end
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_19_235758) do
+ActiveRecord::Schema.define(version: 2020_12_13_170831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -449,6 +449,10 @@ ActiveRecord::Schema.define(version: 2020_09_19_235758) do
     t.boolean "signed_guidelines"
     t.integer "community_id"
     t.boolean "attended_training"
+    t.string "authy_id"
+    t.datetime "last_sign_in_with_authy"
+    t.boolean "authy_enabled", default: false
+    t.index ["authy_id"], name: "index_users_on_authy_id"
     t.index ["community_id"], name: "index_users_on_community_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,11 +55,11 @@ ActiveRecord::Schema.define(version: 2020_12_13_170831) do
     t.datetime "updated_at", null: false
     t.integer "region_id"
     t.boolean "confirmed"
-    t.text "public_notes"
     t.integer "activity_type_id"
-    t.integer "last_edited_by"
+    t.text "public_notes"
     t.boolean "occur_at_tbd"
     t.datetime "control_date"
+    t.integer "last_edited_by"
     t.index ["activity_type_id"], name: "index_activities_on_activity_type_id"
     t.index ["region_id"], name: "index_activities_on_region_id"
   end
@@ -459,6 +459,7 @@ ActiveRecord::Schema.define(version: 2020_12_13_170831) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["password_changed_at"], name: "index_users_on_password_changed_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true


### PR DESCRIPTION
## Why is this PR needed?

For 2FA!
authy-devise gem: https://github.com/twilio/authy-devise
Authy download: https://authy.com/download

## Stuff to investigate / add
- i want a rake task I'll set up to run daily and that will snitch on anyone who has admin or data_entry permissions, but does NOT have 2FA enabled.  I'll put my email in an ENV var.
- big red button?
- add a column on user for something like 'has_agreed_to_data_entry_policies'
- maybe we can lower the pagination number to 10 on Friend index
- we also want documentation to share with staff and volunteers about what emails are sent by the application and the circumstances that cause these emails to be sent
- open a PR to fix authy-devise migration generated by the generator https://github.com/twilio/authy-devise/blob/4bdab0a05f781dcd55bbbb039377dc705189a37b/lib/generators/active_record/devise_authy_generator.rb