### PR TITLE
Account lock down

### DIFF
--- a/app/controllers/lockdown_controller.rb
+++ b/app/controllers/lockdown_controller.rb
@@ -1,0 +1,28 @@
+class LockdownController < ApplicationController
+    def new
+    end
+
+    def create
+        email = lockdown_params[:email].downcase.strip
+        user = User.find_by_email(email)
+        
+        if user
+            if user.lockdown
+                flash[:success] = "Lockdown succeeded."
+            else
+                flash[:error] = "Lockdown for #{email} failed."
+            end
+        else
+            flash[:error] = "Lockdown for #{email} failed."
+        end
+        redirect_to lockdown_path
+    end
+
+    private
+
+    def lockdown_params
+        params.require(:lockdown).permit(
+            :email
+        )
+    end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,4 +187,9 @@ class User < ApplicationRecord
   def admin_or_existing_relationship?(friend_id)
     admin? || has_active_data_entry_access_time_slot? || existing_relationship?(friend_id)
   end
+
+  def lockdown
+    password = SecureRandom.uuid + SecureRandom.uuid.upcase
+    reset_password(password, password)
+  end
 end

--- a/app/views/lockdown/_form.html.erb
+++ b/app/views/lockdown/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for :lockdown do |f| %>
+  
+  <div class='form-group'>
+    <div class='row'>
+      <%= f.label :email, class: 'col-md-2 control-label required' %>
+    </div>
+    <div class='row'>
+      <div class='col-md-4'>
+        <%= f.text_field :email, autocomplete: 'new', class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+    <div class='row'>
+      <div class='col-md-1'>
+        <%= f.submit 'Lockdown', class: 'btn btn-danger' %>
+      </div>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/lockdown/new.html.erb
+++ b/app/views/lockdown/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
 
   get 'pledge', to: 'home#pledge'
 
+  resources :lockdown, only: [:create] 
+  match 'lockdown', to: 'lockdown#new', via: [:get]
+
   resources :communities, param: :slug, only: [] do
     devise_for :users, only: [:invitations], controllers: { invitations: "invitations" }
 

--- a/spec/features/lockdown_user_spec.rb
+++ b/spec/features/lockdown_user_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'User locks down their account', type: :feature do
+
+  let(:user) { create(:user) }
+
+  context 'when there is a user matching the email' do 
+    scenario 'successfully locks down user account' do
+        visit lockdown_path
+
+        fill_in 'Email', with: user.email
+        click_button 'Lockdown'
+        expect(page).to have_content 'Lockdown succeeded.'
+    end
+  end
+
+  context 'when there is no user matching the email' do
+    scenario 'fails to lock down user account' do
+        visit lockdown_path
+
+        email = user.email + 'a'
+        fill_in 'Email', with: email
+        click_button 'Lockdown'
+        expect(page).to have_content "Lockdown for #{email} failed."
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -99,4 +99,11 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe '#lockdown' do
+    subject(:user) { create :user }
+    it 'sets secure password' do
+      expect { subject.lockdown }.to change { subject.encrypted_password }
+    end
+  end
 end


### PR DESCRIPTION
## Why is this PR needed?

It's part of the new 2FA implementation.

## Solution

This PR locks down the account for any supplied email address. Resets password, ends all sessions. Authentication not required. Access feature at /lockdown.

### Link to associated issue: 

https://github.com/CZagrobelny/new_sanctuary_asylum/issues/365