### PR TITLE
Account lockdown alert mailer

### DIFF
--- a/app/mailers/account_lockdown_alert_mailer.rb
+++ b/app/mailers/account_lockdown_alert_mailer.rb
@@ -1,0 +1,7 @@
+class ReviewMailer < ApplicationMailer
+  def account_lockdown_email(user)
+    @user = user
+    admin_emails = user.community.region.regional_admins.pluck(:email)
+    mail(to: admin_emails, subject: "Account lockdown warning")
+  end
+end

--- a/app/views/account_lockdown_alert_mailer/account_lockdown_alert_email.html.erb
+++ b/app/views/account_lockdown_alert_mailer/account_lockdown_alert_email.html.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>
+      The account for <%= @user.name %> (user ID: <%= @user.id %>) has been locked down
+    </p>
+</html>

--- a/app/views/account_lockdown_alert_mailer/account_lockdown_alert_email.text.erb
+++ b/app/views/account_lockdown_alert_mailer/account_lockdown_alert_email.text.erb
@@ -1,0 +1,1 @@
+The account for <%= @user.name %> (user ID: <%= @user.id %>) has been locked down


### PR DESCRIPTION
## Why is this PR needed?

This will alert admins when an account has been locked down, which we need for strengthened security.

## Solution

Implements a mailer and associated templates.

### Link to associated issue: 

https://github.com/CZagrobelny/new_sanctuary_asylum/issues/374
