### PR TITLE
Improve Access Time Slot record-keeping

### DIFF
--- a/app/controllers/admin/access_time_slots_controller.rb
+++ b/app/controllers/admin/access_time_slots_controller.rb
@@ -7,6 +7,10 @@ class Admin::AccessTimeSlotsController < AdminController
     @access_time_slots = current_community.access_time_slots
   end
 
+  def show
+    access_time_slot
+  end
+
   def new
     @access_time_slot_type = params[:type]
     @access_time_slot = AccessTimeSlot.new

--- a/app/controllers/admin/access_time_slots_controller.rb
+++ b/app/controllers/admin/access_time_slots_controller.rb
@@ -71,13 +71,13 @@ class Admin::AccessTimeSlotsController < AdminController
   end
 
   def require_active_time_slot
-    if access_time_slot.start_time.after?(Time.now) || access_time_slot.end_time.before?(Time.now)
+    unless access_time_slot.active?
       not_found
     end
   end
 
   def require_time_slot_in_future
-    if access_time_slot.start_time.before?(Time.now)
+    unless access_time_slot.future?
       not_found
     end
   end

--- a/app/controllers/admin/access_time_slots_controller.rb
+++ b/app/controllers/admin/access_time_slots_controller.rb
@@ -1,6 +1,7 @@
 class Admin::AccessTimeSlotsController < AdminController
   before_action :require_admin
   before_action :require_time_slot_in_future, only: [:edit, :update, :destroy]
+  before_action :require_active_time_slot, only: [:deactivate]
 
   def index
     @access_time_slots = current_community.access_time_slots
@@ -35,6 +36,15 @@ class Admin::AccessTimeSlotsController < AdminController
     end
   end
 
+  def deactivate
+    if access_time_slot.update(deactivated: true)
+      flash[:success] = 'Access time slot successfully deactivated.'
+    else
+      flash[:error] = 'There was an issue deactivating the access time slot.'
+    end
+    redirect_to community_admin_access_time_slots_path
+  end
+
   def destroy
     if access_time_slot.destroy
       flash[:success] = 'Access time slot successfully deleted.'
@@ -58,6 +68,12 @@ class Admin::AccessTimeSlotsController < AdminController
       :grantor_id,
       :grantee_id,
     ).merge(community_id: current_community.id)
+  end
+
+  def require_active_time_slot
+    if access_time_slot.start_time.after?(Time.now) || access_time_slot.end_time.before?(Time.now)
+      not_found
+    end
   end
 
   def require_time_slot_in_future

--- a/app/controllers/admin/access_time_slots_controller.rb
+++ b/app/controllers/admin/access_time_slots_controller.rb
@@ -1,5 +1,6 @@
 class Admin::AccessTimeSlotsController < AdminController
   before_action :require_admin
+  before_action :require_time_slot_in_future, only: [:edit, :update, :destroy]
 
   def index
     @access_time_slots = current_community.access_time_slots
@@ -57,5 +58,11 @@ class Admin::AccessTimeSlotsController < AdminController
       :grantor_id,
       :grantee_id,
     ).merge(community_id: current_community.id)
+  end
+
+  def require_time_slot_in_future
+    if access_time_slot.start_time.before?(Time.now)
+      not_found
+    end
   end
 end

--- a/app/models/access_time_slot.rb
+++ b/app/models/access_time_slot.rb
@@ -14,6 +14,14 @@ class AccessTimeSlot < ApplicationRecord
 
   scope :active, -> { where('start_time < :current_time AND end_time > :current_time AND NOT deactivated', current_time: Time.now) }
 
+  def active?
+    start_time.before?(Time.now) && end_time.after?(Time.now)
+  end
+
+  def future?
+    start_time.after?(Time.now)
+  end
+
   private
 
   def end_time_is_after_start_time

--- a/app/models/access_time_slot.rb
+++ b/app/models/access_time_slot.rb
@@ -12,7 +12,7 @@ class AccessTimeSlot < ApplicationRecord
   validate :time_range_under_ten_hours
   validate :permitted_use_for_grantee_user_role
 
-  scope :active, -> { where('start_time < ? AND end_time > ?', Time.now, Time.now) }
+  scope :active, -> { where('start_time < :current_time AND end_time > :current_time AND NOT deactivated', current_time: Time.now) }
 
   private
 

--- a/app/models/access_time_slot.rb
+++ b/app/models/access_time_slot.rb
@@ -15,7 +15,7 @@ class AccessTimeSlot < ApplicationRecord
   scope :active, -> { where('start_time < :current_time AND end_time > :current_time AND NOT deactivated', current_time: Time.now) }
 
   def active?
-    start_time.before?(Time.now) && end_time.after?(Time.now)
+    start_time.before?(Time.now) && end_time.after?(Time.now) && !deactivated?
   end
 
   def future?

--- a/app/views/admin/access_time_slots/edit.html.erb
+++ b/app/views/admin/access_time_slots/edit.html.erb
@@ -1,3 +1,9 @@
 <h1>Edit Access Time Slot</h1>
-<%= link_to 'Delete', community_admin_access_time_slot_path(current_community, @access_time_slot), method: :delete, class: 'btn btn-sm btn-danger pull-right' %>
+
+<% if @access_time_slot.active? %>
+  <%= link_to 'Deactivate', deactivate_community_admin_access_time_slot_path(current_community, @access_time_slot), method: :patch, class: 'btn btn-sm btn-default pull-right' %>
+<% elsif @access_time_slot.future? %>
+  <%= link_to 'Delete', community_admin_access_time_slot_path(current_community, @access_time_slot), method: :delete, class: 'btn btn-sm btn-danger pull-right' %>
+<% end %>
+
 <%= render partial: 'form', locals: { access_time_slot: @access_time_slot } %>

--- a/app/views/admin/access_time_slots/index.html.erb
+++ b/app/views/admin/access_time_slots/index.html.erb
@@ -12,7 +12,7 @@
         <%= "#{access_time_slot.start_time.strftime("%_I:%M %p")} - #{access_time_slot.end_time.strftime("%_I:%M %p")}" %>
       </dt>
       <dd>
-        <%= link_to "#{access_time_slot.grantee.name} (#{access_time_slot.use.titlecase})",edit_community_admin_access_time_slot_path(current_community, access_time_slot), class: "#{'eoir_caller' if access_time_slot.grantee.role == 'eoir_caller'}" %>
+        <%= link_to "#{access_time_slot.grantee.name} (#{access_time_slot.use.titlecase})", community_admin_access_time_slot_path(current_community, access_time_slot), class: "#{'eoir_caller' if access_time_slot.grantee.role == 'eoir_caller'}" %>
       </dd>
   <% end %>
   </dl>

--- a/app/views/admin/access_time_slots/index.html.erb
+++ b/app/views/admin/access_time_slots/index.html.erb
@@ -13,6 +13,9 @@
       </dt>
       <dd>
         <%= link_to "#{access_time_slot.grantee.name} (#{access_time_slot.use.titlecase})", community_admin_access_time_slot_path(current_community, access_time_slot), class: "#{'eoir_caller' if access_time_slot.grantee.role == 'eoir_caller'}" %>
+        <% if access_time_slot.deactivated? %>
+          <span class="label label-default">Deactivated</span>
+        <% end %>
       </dd>
   <% end %>
   </dl>

--- a/app/views/admin/access_time_slots/show.html.erb
+++ b/app/views/admin/access_time_slots/show.html.erb
@@ -1,0 +1,23 @@
+<h1>Access Time Slot</h1>
+
+<div>
+  <%= "#{@access_time_slot.start_time.strftime("%B %-d %_I:%M %p")} - #{@access_time_slot.end_time.strftime("%_I:%M %p")}" %>
+</div>
+
+<div>
+  <%= @access_time_slot.use.titlecase %>
+</div>
+
+<dt>User</dt>
+<dd>
+  <%= @access_time_slot.grantee.name %>
+</dd>
+
+<dt>Created by</dt>
+<dd>
+  <%= @access_time_slot.grantor.try(:name) %>
+</dd>
+
+<% if @access_time_slot.future? %>
+  <%= link_to 'Edit', edit_community_admin_access_time_slot_path(current_community, @access_time_slot), class: 'btn btn-sm btn-default' %>
+<% end %>

--- a/app/views/admin/access_time_slots/show.html.erb
+++ b/app/views/admin/access_time_slots/show.html.erb
@@ -1,4 +1,10 @@
-<h1>Access Time Slot</h1>
+<h1>
+  Access Time Slot
+
+  <% if @access_time_slot.deactivated? %>
+    <span class="label label-warning">Deactivated</span>
+  <% end %>
+</h1>
 
 <div>
   <%= "#{@access_time_slot.start_time.strftime("%B %-d %_I:%M %p")} - #{@access_time_slot.end_time.strftime("%_I:%M %p")}" %>
@@ -18,6 +24,9 @@
   <%= @access_time_slot.grantor.try(:name) %>
 </dd>
 
-<% if @access_time_slot.future? %>
+<% if @access_time_slot.active? %>
+  <%= link_to 'Deactivate', deactivate_community_admin_access_time_slot_path(current_community, @access_time_slot), method: :patch, class: 'btn btn-sm btn-default' %>
+<% elsif @access_time_slot.future? %>
   <%= link_to 'Edit', edit_community_admin_access_time_slot_path(current_community, @access_time_slot), class: 'btn btn-sm btn-default' %>
+  <%= link_to 'Delete', community_admin_access_time_slot_path(current_community, @access_time_slot), method: :delete, class: 'btn btn-sm btn-danger' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
           get :select2_options
         end
       end
-      resources :access_time_slots, except: [:show] do
+      resources :access_time_slots do
         member do
           patch :deactivate
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,7 +53,11 @@ Rails.application.routes.draw do
           get :select2_options
         end
       end
-      resources :access_time_slots, except: [:show]
+      resources :access_time_slots, except: [:show] do
+        member do
+          patch :deactivate
+        end
+      end
       resources :activities, except: [:destroy] do
         collection do
           get :accompaniments

--- a/db/migrate/20210120013839_add_deactivated_to_access_time_slots.rb
+++ b/db/migrate/20210120013839_add_deactivated_to_access_time_slots.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedToAccessTimeSlots < ActiveRecord::Migration[6.0]
+  def change
+    add_column :access_time_slots, :deactivated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_26_145828) do
+ActiveRecord::Schema.define(version: 2021_01_20_013839) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 2020_12_26_145828) do
     t.bigint "community_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "deactivated", default: false
     t.index ["community_id"], name: "index_access_time_slots_on_community_id"
   end
 

--- a/spec/controllers/admin_access/access_time_slots_controller_spec.rb
+++ b/spec/controllers/admin_access/access_time_slots_controller_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe Admin::AccessTimeSlotsController, type: :controller do
         expect{ AccessTimeSlot.find(time_slot.id) }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+
+    describe 'PATCH #deactivate' do
+      it 'does NOT allow access' do
+        expect do
+          patch :deactivate, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+        expect(time_slot.reload).not_to be_deactivated
+      end
+    end
   end
 
   context 'time slot is ongoing now' do
@@ -64,6 +73,13 @@ RSpec.describe Admin::AccessTimeSlotsController, type: :controller do
         expect(AccessTimeSlot.find(time_slot.id)).to eq time_slot
       end
     end
+
+    describe 'PATCH #deactivate' do
+      it 'allows access' do
+        patch :deactivate, params: {community_slug: community.slug, id: time_slot.id}
+        expect(time_slot.reload).to be_deactivated
+      end
+    end
   end
 
   context 'time slot is in the past' do
@@ -93,6 +109,15 @@ RSpec.describe Admin::AccessTimeSlotsController, type: :controller do
           delete :destroy, params: {community_slug: community.slug, id: time_slot.id}
         end.to raise_error('Not Found')
         expect(AccessTimeSlot.find(time_slot.id)).to eq time_slot
+      end
+    end
+
+    describe 'PATCH #deactivate' do
+      it 'does NOT allow access' do
+        expect do
+          patch :deactivate, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+        expect(time_slot.reload).not_to be_deactivated
       end
     end
   end

--- a/spec/controllers/admin_access/access_time_slots_controller_spec.rb
+++ b/spec/controllers/admin_access/access_time_slots_controller_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe Admin::AccessTimeSlotsController, type: :controller do
+  let(:community) { create :community, :primary }
+  let(:community_admin) { create :user, :community_admin, community: community }
+
+  before do
+    allow(controller).to receive(:authenticate_user!).and_return(true)
+    allow(controller).to receive(:current_user).and_return(community_admin)
+  end
+
+  context 'time slot in the future' do
+    let(:time_slot) { create(:access_time_slot, start_time: 1.hour.from_now, end_time: 2.hours.from_now, use: :data_entry) }
+
+    describe 'GET #edit' do
+      it 'allows access' do
+        get :edit, params: {community_slug: community.slug, id: time_slot.id}
+        expect(response).to be_successful
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'allows access' do
+        patch :update, params: {community_slug: community.slug, id: time_slot.id,
+                                access_time_slot: {use: :clinic_support}}
+        expect(time_slot.reload.use).to eq 'clinic_support'
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'allows access' do
+        delete :destroy, params: {community_slug: community.slug, id: time_slot.id}
+        expect{ AccessTimeSlot.find(time_slot.id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  context 'time slot is ongoing now' do
+    let(:time_slot) { create(:access_time_slot, start_time: 1.hour.ago, end_time: 1.hour.from_now, use: :data_entry) }
+
+    describe 'GET #edit' do
+      it 'does NOT allow access' do
+        expect do
+          get :edit, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'does NOT allow access' do
+        expect do
+          patch :update, params: {community_slug: community.slug, id: time_slot.id,
+                                  access_time_slot: {use: :clinic_support}}
+        end.to raise_error('Not Found')
+        expect(time_slot.reload.use).to eq 'data_entry'
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'does NOT allow access' do
+        expect do
+          delete :destroy, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+        expect(AccessTimeSlot.find(time_slot.id)).to eq time_slot
+      end
+    end
+  end
+
+  context 'time slot is in the past' do
+    let(:time_slot) { create(:access_time_slot, start_time: 2.hours.ago, end_time: 1.hour.ago, use: :data_entry) }
+
+    describe 'GET #edit' do
+      it 'does NOT allow access' do
+        expect do
+          get :edit, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+      end
+    end
+
+    describe 'PATCH #update' do
+      it 'does NOT allow access' do
+        expect do
+          patch :update, params: {community_slug: community.slug, id: time_slot.id,
+                                  access_time_slot: {use: :clinic_support}}
+        end.to raise_error('Not Found')
+        expect(time_slot.reload.use).to eq 'data_entry'
+      end
+    end
+
+    describe 'DELETE #destroy' do
+      it 'does NOT allow access' do
+        expect do
+          delete :destroy, params: {community_slug: community.slug, id: time_slot.id}
+        end.to raise_error('Not Found')
+        expect(AccessTimeSlot.find(time_slot.id)).to eq time_slot
+      end
+    end
+  end
+end

--- a/spec/factories/access_time_slot_factory.rb
+++ b/spec/factories/access_time_slot_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :access_time_slot do
+    start_time { 1.hour.from_now }
+    end_time { 3.hours.from_now }
+    use { AccessTimeSlot::DATA_ENTRY_USES.sample }
+    association :grantor, factory: :user
+    association :grantee, factory: :user, role: :data_entry
+    association :community
+  end
+end

--- a/spec/models/access_time_slot_spec.rb
+++ b/spec/models/access_time_slot_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AccessTimeSlot, type: :model do
+  describe '.active' do
+    let!(:future_slot) { create(:access_time_slot, start_time: 1.hour.from_now, end_time: 2.hours.from_now) }
+    let!(:current_slot) { create(:access_time_slot, start_time: 1.hour.ago, end_time: 1.hour.from_now) }
+    let!(:past_slot) { create(:access_time_slot, start_time: 2.hours.ago, end_time: 1.hour.ago) }
+    let!(:current_deactivated_slot) { create(:access_time_slot, start_time: 1.hour.ago, end_time: 1.hour.from_now,
+                                             deactivated: true) }
+
+    specify { expect(AccessTimeSlot.active).to contain_exactly(current_slot) }
+  end
+end


### PR DESCRIPTION
## Why is this PR needed?
- Improves audit-ability of access time slots by ensuring they cannot be deleted or edited once they have started.
- Adds the ability to "deactivate" an access time slot in progress, so it no longer provides access

## Solution
I added some checks to the controller for the existing `#edit`, `#update`, and `#destroy` actions, and added the new `#deactivate` action. I also added a new `#show` route that shows some basic information about the access time slot, and changed the calendar to link to the `#show` page. This avoids errors when viewing access time slots in the past.

Calendar:
![cal-with-deactivated](https://user-images.githubusercontent.com/1977279/105926090-4eef1780-600f-11eb-886c-d654dd2e31cd.png)

new Show page for an active time slot:
![curent](https://user-images.githubusercontent.com/1977279/105926143-6deda980-600f-11eb-8fb0-57f6998818df.png)

and a future time slot:
![future](https://user-images.githubusercontent.com/1977279/105926153-734af400-600f-11eb-8889-cc9db39375a0.png)


### Link to associated issue: 
https://github.com/CZagrobelny/new_sanctuary_asylum/issues/372